### PR TITLE
Fix Container Image Publication Metadata

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -64,11 +64,7 @@ jobs:
             --set "runtime.output=type=image,name=${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file /tmp/metadata.json \
             runtime
-          digest="$(jq -r '.runtime["containerimage.digest"]' /tmp/metadata.json)"
-          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "generic build returned an invalid image digest: ${digest}" >&2
-            exit 1
-          fi
+          digest="$(python3 images/scripts/read_buildx_digest.py /tmp/metadata.json runtime)"
           mkdir -p /tmp/digests
           touch "/tmp/digests/${digest#sha256:}"
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
@@ -199,9 +195,9 @@ jobs:
           else
             docker buildx imagetools create \
               --tag "${commit_ref}" \
-              --metadata-file /tmp/generic-commit-metadata.json \
               "${sources[@]}"
-            commit_digest="$(jq -r '.containerimage.descriptor.digest' /tmp/generic-commit-metadata.json)"
+            inspect_output="$(docker buildx imagetools inspect "${commit_ref}")"
+            commit_digest="$(awk '$1 == "Digest:" {print $2; exit}' <<<"${inspect_output}")"
             raw="$(docker buildx imagetools inspect --raw "${commit_ref}")"
             published_manifest="$(jq -cS '.manifests |= sort_by(.digest)' <<<"${raw}")"
             if [ "${published_manifest}" != "${proposed_manifest}" ]; then
@@ -235,10 +231,13 @@ jobs:
           fi
           docker buildx imagetools create \
             --tag "${IMAGE_NAME}:${IMAGE_CHANNEL}" \
-            --metadata-file /tmp/generic-edge-metadata.json \
             "${IMAGE_NAME}:sha-${GIT_SHA}"
-          edge_digest="$(jq -r '.containerimage.descriptor.digest' /tmp/generic-edge-metadata.json)"
-          test "${edge_digest}" = "${COMMIT_DIGEST}"
+          inspect_output="$(docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_CHANNEL}")"
+          edge_digest="$(awk '$1 == "Digest:" {print $2; exit}' <<<"${inspect_output}")"
+          if [ "${edge_digest}" != "${COMMIT_DIGEST}" ]; then
+            echo "promoted generic channel digest does not match the immutable commit tag" >&2
+            exit 1
+          fi
           docker pull --platform linux/amd64 "${IMAGE_NAME}:${IMAGE_CHANNEL}"
 
   build-terra:
@@ -272,11 +271,7 @@ jobs:
             --set "terra-runtime.output=type=image,name=${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=false" \
             --metadata-file /tmp/terra-metadata.json \
             terra-runtime
-          digest="$(jq -r '.terra-runtime["containerimage.digest"]' /tmp/terra-metadata.json)"
-          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "Terra build returned an invalid image digest: ${digest}" >&2
-            exit 1
-          fi
+          digest="$(python3 images/scripts/read_buildx_digest.py /tmp/terra-metadata.json terra-runtime)"
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           echo "reference=${IMAGE_NAME}@${digest}" >> "${GITHUB_OUTPUT}"
       - name: Verify staged Terra registry contract
@@ -357,9 +352,9 @@ jobs:
           else
             docker buildx imagetools create --prefer-index=false \
               --tag "${commit_ref}" \
-              --metadata-file /tmp/terra-commit-metadata.json \
               "${CANDIDATE_REFERENCE}"
-            commit_digest="$(jq -r '.containerimage.descriptor.digest' /tmp/terra-commit-metadata.json)"
+            inspect_output="$(docker buildx imagetools inspect "${commit_ref}")"
+            commit_digest="$(awk '$1 == "Digest:" {print $2; exit}' <<<"${inspect_output}")"
           fi
           if [[ ! "${commit_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "Terra commit tag returned an invalid image digest: ${commit_digest}" >&2
@@ -393,10 +388,13 @@ jobs:
           fi
           docker buildx imagetools create --prefer-index=false \
             --tag "${IMAGE_NAME}:${IMAGE_CHANNEL}-terra" \
-            --metadata-file /tmp/terra-edge-metadata.json \
             "${IMAGE_NAME}:sha-${GIT_SHA}-terra"
-          edge_digest="$(jq -r '.containerimage.descriptor.digest' /tmp/terra-edge-metadata.json)"
-          test "${edge_digest}" = "${COMMIT_DIGEST}"
+          inspect_output="$(docker buildx imagetools inspect "${IMAGE_NAME}:${IMAGE_CHANNEL}-terra")"
+          edge_digest="$(awk '$1 == "Digest:" {print $2; exit}' <<<"${inspect_output}")"
+          if [ "${edge_digest}" != "${COMMIT_DIGEST}" ]; then
+            echo "promoted Terra channel digest does not match the immutable commit tag" >&2
+            exit 1
+          fi
           python3 images/platform/scripts/verify_registry_manifest.py \
             --manifest images/platforms.toml \
             --platform terra \

--- a/images/scripts/read_buildx_digest.py
+++ b/images/scripts/read_buildx_digest.py
@@ -1,0 +1,50 @@
+# This source file is part of the Heartwood open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+
+"""Read and validate one target digest from Docker Buildx Bake metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the selected target digest or return a nonzero status."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("metadata", type=Path)
+    parser.add_argument("target")
+    args = parser.parse_args(argv)
+    try:
+        digest = _target_digest(args.metadata, args.target)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"invalid Buildx metadata: {error}", file=sys.stderr)
+        return 1
+    print(digest)
+    return 0
+
+
+def _target_digest(metadata_path: Path, target: str) -> str:
+    metadata: Any = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if not isinstance(metadata, dict):
+        raise ValueError("root must be an object")
+    target_metadata = metadata.get(target)
+    if not isinstance(target_metadata, dict):
+        raise ValueError(f"target {target!r} is missing")
+    digest = target_metadata.get("containerimage.digest")
+    if not isinstance(digest, str) or _DIGEST.fullmatch(digest) is None:
+        raise ValueError(f"target {target!r} has no valid container image digest")
+    return digest
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -245,6 +245,9 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
 
     assert "packages: write" in publish
     assert "push-by-digest=true" in publish
+    assert publish.count("images/scripts/read_buildx_digest.py") == 2
+    assert ".containerimage.descriptor.digest" not in publish
+    assert ".terra-runtime" not in publish
     assert "actions/upload-artifact@v7" in publish
     assert "actions/download-artifact@v8" in publish
     assert '"${IMAGE_NAME}:${IMAGE_CHANNEL}"' in publish
@@ -259,12 +262,14 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
     assert "verify_registry_manifest.py" in publish
     assert "--prefer-index=false" in publish
     assert '--reference "${CANDIDATE_DIGEST}"' in publish
-    assert publish.count("^sha256:[0-9a-f]{64}$") == 4
+    assert publish.count("^sha256:[0-9a-f]{64}$") == 2
     assert publish.count("if: github.ref == 'refs/heads/main'") == 3
     assert "immutable generic commit tag already exists with a different manifest" in publish
     assert "newly created generic commit tag does not match validated candidate manifest" in publish
     assert "immutable Terra commit tag already exists with a different digest" in publish
     assert "newly created Terra commit tag does not match staged candidate digest" in publish
+    assert "promoted generic channel digest does not match the immutable commit tag" in publish
+    assert "promoted Terra channel digest does not match the immutable commit tag" in publish
     assert (
         'if inspect_output="$(docker buildx imagetools inspect "${commit_ref}" 2>/dev/null)"; then'
         in publish
@@ -332,6 +337,53 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
     assert 'summary["source_participant_count"] != 24' in capable_model
     assert 'summary["participant_count"] != 20' in capable_model
     assert 'checks["row_values_exported"] is not False' in capable_model
+
+
+def test_buildx_metadata_reader_handles_runtime_target_names(tmp_path: Path) -> None:
+    digest = "sha256:" + ("a" * 64)
+    metadata = tmp_path / "metadata.json"
+    metadata.write_text(
+        json.dumps(
+            {
+                "runtime": {"containerimage.digest": digest},
+                "terra-runtime": {"containerimage.digest": digest},
+            }
+        ),
+        encoding="utf-8",
+    )
+    script = _repo_root() / "images/scripts/read_buildx_digest.py"
+
+    for target in ("runtime", "terra-runtime"):
+        completed = subprocess.run(
+            [sys.executable, str(script), str(metadata), target],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0, completed.stderr
+        assert completed.stdout.strip() == digest
+
+    missing = subprocess.run(
+        [sys.executable, str(script), str(metadata), "missing-target"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert missing.returncode != 0
+    assert "target 'missing-target' is missing" in missing.stderr
+
+    metadata.write_text(
+        json.dumps({"runtime": {"containerimage.digest": "invalid"}}),
+        encoding="utf-8",
+    )
+    invalid = subprocess.run(
+        [sys.executable, str(script), str(metadata), "runtime"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert invalid.returncode != 0
+    assert "has no valid container image digest" in invalid.stderr
 
 
 def test_platform_registry_verifier_checks_only_public_terra_tags(tmp_path: Path) -> None:


### PR DESCRIPTION
# Fix Container Image Publication Metadata

## :recycle: Current Situation & Problem

The main image publication workflow failed after successfully building and validating both generic architectures. The generic immutable multi-platform tag and `edge` tag were pushed, but the workflow read the `imagetools create` metadata with `.containerimage.descriptor.digest`, which treats the dotted key as nested JSON properties and returns `null`. The following digest equality check therefore reported a false failure after promotion.

The Terra candidate image was also pushed, but its build stopped before validation because `.terra-runtime["containerimage.digest"]` parses the hyphenated target name as a jq subtraction expression. The failure is visible in [Container Image run 29168260062](https://github.com/SchmiedmayerLab/heartwood/actions/runs/29168260062).

## :gear: Release Notes

- Parse Docker Buildx Bake metadata with a small validated JSON reader that supports both `runtime` and `terra-runtime` target names.
- Validate the target and require a canonical SHA-256 container digest before creating digest artifacts or candidate references.
- Stop depending on the separate `imagetools create --metadata-file` layout during immutable and moving-tag promotion.
- Inspect each published registry reference after creation and compare its actual digest with the validated immutable digest.
- Emit explicit generic and Terra promotion mismatch errors instead of a silent shell `test` failure.
- Add regression coverage for generic and hyphenated Terra target names, missing targets, invalid digests, and workflow wiring.

## :books: Documentation

No user-facing image name, tag, platform, manifest, or runtime behavior changes. The existing container documentation remains accurate.

## :white_check_mark: Testing

- `pytest`: 358 passed with 90.71% total coverage.
- Container asset contract tests: 11 passed.
- `ruff check .`, `ruff format --check .`, and `mypy packages` pass.
- `actionlint` and `yamllint` pass for the updated publication workflow.
- REUSE validation passes for all 236 tracked files.
- `git diff --check` passes.
- Registry inspection confirms `ghcr.io/schmiedmayerlab/heartwood:edge` is a valid AMD64 and ARM64 OCI index at the digest recorded by the failed workflow; the previous generic failure occurred after a successful tag push.

### Code Of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
