### PR TITLE
Enforce Terra GPU Manifest Compatibility

### DIFF
--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -126,6 +126,7 @@ jobs:
       - name: Build candidate by digest
         id: candidate
         env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
           IMAGE_NAME: ${{ steps.image.outputs.name }}
           TARGET: ${{ matrix.target }}
           MEDIA_OUTPUT: ${{ matrix.media_output }}
@@ -173,6 +174,18 @@ jobs:
           if [ "${commit_digest}" != "${CANDIDATE_DIGEST}" ]; then
             echo "immutable GPU commit tag does not match the validated candidate" >&2
             exit 1
+          fi
+          raw="$(docker buildx imagetools inspect --raw "${commit_ref}")"
+          if [ "${FLATTEN}" = "true" ]; then
+            jq --exit-status '
+              .mediaType == "application/vnd.docker.distribution.manifest.v2+json"
+              and .config.mediaType == "application/vnd.docker.container.image.v1+json"
+            ' <<<"${raw}" >/dev/null
+          else
+            jq --exit-status '
+              [.manifests[] | select(.platform.os == "linux") | "\(.platform.os)/\(.platform.architecture)"]
+              == ["linux/amd64"]
+            ' <<<"${raw}" >/dev/null
           fi
 
   promote:

--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -177,15 +177,32 @@ jobs:
           fi
           raw="$(docker buildx imagetools inspect --raw "${commit_ref}")"
           if [ "${FLATTEN}" = "true" ]; then
-            jq --exit-status '
+            if ! jq --exit-status '
               .mediaType == "application/vnd.docker.distribution.manifest.v2+json"
               and .config.mediaType == "application/vnd.docker.container.image.v1+json"
-            ' <<<"${raw}" >/dev/null
+            ' <<<"${raw}" >/dev/null; then
+              media_type="$(jq -r '.mediaType // "<missing>"' <<<"${raw}")"
+              config_media_type="$(jq -r '.config.mediaType // "<missing>"' <<<"${raw}")"
+              echo "immutable Terra GPU tag has incompatible media types: ${commit_ref}" >&2
+              echo "observed media type: ${media_type}; config media type: ${config_media_type}" >&2
+              exit 1
+            fi
           else
-            jq --exit-status '
+            if ! jq --exit-status '
               [.manifests[] | select(.platform.os == "linux") | "\(.platform.os)/\(.platform.architecture)"]
               == ["linux/amd64"]
-            ' <<<"${raw}" >/dev/null
+            ' <<<"${raw}" >/dev/null; then
+              media_type="$(jq -r '.mediaType // "<missing>"' <<<"${raw}")"
+              platforms="$(
+                jq -r '
+                  [.manifests[]? | select(.platform.os == "linux") | "\(.platform.os)/\(.platform.architecture)"]
+                  | join(", ")
+                ' <<<"${raw}"
+              )"
+              echo "immutable generic GPU tag has an incompatible index: ${commit_ref}" >&2
+              echo "observed media type: ${media_type}; Linux platforms: ${platforms:-<none>}" >&2
+              exit 1
+            fi
           fi
 
   promote:

--- a/deploy/promote-release-images.sh
+++ b/deploy/promote-release-images.sh
@@ -63,25 +63,38 @@ for mapping in "${mappings[@]}"; do
   IFS='|' read -r source_tag target_tag media_shape <<<"${mapping}"
   source_ref="${image_name}:${source_tag}"
   target_ref="${image_name}:${target_tag}"
+  echo "verifying release image candidate: ${source_ref}"
   source_digest="$(digest "${source_ref}")"
-  [[ "${source_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+  if [[ ! "${source_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "release image candidate returned an invalid digest: ${source_ref}" >&2
+    exit 1
+  fi
 
   raw="$(imagetools_inspect --raw "${source_ref}")"
   if [[ "${media_shape}" == "single" ]]; then
-    jq -e '
+    if ! jq -e '
       .mediaType == "application/vnd.docker.distribution.manifest.v2+json"
       and .config.mediaType == "application/vnd.docker.container.image.v1+json"
-    ' <<<"${raw}" >/dev/null
+    ' <<<"${raw}" >/dev/null; then
+      echo "release image candidate is not a Docker schema-2 manifest: ${source_ref}" >&2
+      exit 1
+    fi
   elif [[ "${media_shape}" == "multi" ]]; then
-    jq -e '
+    if ! jq -e '
       ([.manifests[] | select(.platform.os == "linux") | "\(.platform.os)/\(.platform.architecture)"] | sort)
       == ["linux/amd64", "linux/arm64"]
-    ' <<<"${raw}" >/dev/null
+    ' <<<"${raw}" >/dev/null; then
+      echo "release image candidate is not an AMD64/ARM64 index: ${source_ref}" >&2
+      exit 1
+    fi
   else
-    jq -e '
+    if ! jq -e '
       [.manifests[] | select(.platform.os == "linux") | "\(.platform.os)/\(.platform.architecture)"]
       == ["linux/amd64"]
-    ' <<<"${raw}" >/dev/null
+    ' <<<"${raw}" >/dev/null; then
+      echo "release image candidate is not an AMD64 index: ${source_ref}" >&2
+      exit 1
+    fi
   fi
 
   if [[ "${mode}" == "verify" ]]; then

--- a/deploy/promote-release-images.sh
+++ b/deploy/promote-release-images.sh
@@ -66,17 +66,21 @@ for mapping in "${mappings[@]}"; do
   echo "verifying release image candidate: ${source_ref}"
   source_digest="$(digest "${source_ref}")"
   if [[ ! "${source_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-    echo "release image candidate returned an invalid digest: ${source_ref}" >&2
+    echo "release image candidate returned an invalid digest: ${source_ref} (${source_digest:-<empty>})" >&2
     exit 1
   fi
 
   raw="$(imagetools_inspect --raw "${source_ref}")"
+  media_type="$(jq -r '.mediaType // "<missing>"' <<<"${raw}")"
+  config_media_type="$(jq -r '.config.mediaType // "<missing>"' <<<"${raw}")"
+  platforms="$(jq -r '[.manifests[]? | select(.platform.os == "linux") | "\(.platform.os)/\(.platform.architecture)"] | join(", ")' <<<"${raw}")"
   if [[ "${media_shape}" == "single" ]]; then
     if ! jq -e '
       .mediaType == "application/vnd.docker.distribution.manifest.v2+json"
       and .config.mediaType == "application/vnd.docker.container.image.v1+json"
     ' <<<"${raw}" >/dev/null; then
       echo "release image candidate is not a Docker schema-2 manifest: ${source_ref}" >&2
+      echo "observed media type: ${media_type}; config media type: ${config_media_type}" >&2
       exit 1
     fi
   elif [[ "${media_shape}" == "multi" ]]; then
@@ -85,6 +89,7 @@ for mapping in "${mappings[@]}"; do
       == ["linux/amd64", "linux/arm64"]
     ' <<<"${raw}" >/dev/null; then
       echo "release image candidate is not an AMD64/ARM64 index: ${source_ref}" >&2
+      echo "observed media type: ${media_type}; Linux platforms: ${platforms:-<none>}" >&2
       exit 1
     fi
   else
@@ -93,6 +98,7 @@ for mapping in "${mappings[@]}"; do
       == ["linux/amd64"]
     ' <<<"${raw}" >/dev/null; then
       echo "release image candidate is not an AMD64 index: ${source_ref}" >&2
+      echo "observed media type: ${media_type}; Linux platforms: ${platforms:-<none>}" >&2
       exit 1
     fi
   fi

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -344,7 +344,9 @@ def test_gpu_publication_builds_only_explicit_main_variants() -> None:
     assert "Promote GPU Channel Tags" in workflow
     assert "if: github.ref == 'refs/heads/main'" in workflow
     assert "push-by-digest=true" in workflow
+    assert 'BUILDX_NO_DEFAULT_ATTESTATIONS: "1"' in workflow
     assert "--prefer-index=false" in workflow
+    assert "application/vnd.docker.distribution.manifest.v2+json" in workflow
     assert "/opt/heartwood-vllm/bin/python" in workflow
     assert "find" in workflow
     assert "-size +10M" in workflow

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -299,6 +299,7 @@ def test_native_release_assets_are_verified_before_installation() -> None:
     workflow = _read(".github/workflows/native-release.yml")
     main_workflow = _read(".github/workflows/main-validation.yml")
     release_workflow = _read(".github/workflows/create-release.yml")
+    release_images = _read("deploy/promote-release-images.sh")
     smoke = _read("deploy/tests/native_installer_smoke.sh")
 
     assert "sha256sum --check --strict" in installer
@@ -326,6 +327,8 @@ def test_native_release_assets_are_verified_before_installation() -> None:
     assert "verify_release_candidate.py" in release_workflow
     assert "promote-release-images.sh verify" in release_workflow
     assert "promote-release-images.sh promote" in release_workflow
+    assert "observed media type:" in release_images
+    assert "Linux platforms:" in release_images
     assert "Build And Verify Native Assets" in workflow
     assert "native_installer_smoke.sh" in workflow
     assert "installer accepted a corrupted checksum" in smoke
@@ -347,6 +350,8 @@ def test_gpu_publication_builds_only_explicit_main_variants() -> None:
     assert 'BUILDX_NO_DEFAULT_ATTESTATIONS: "1"' in workflow
     assert "--prefer-index=false" in workflow
     assert "application/vnd.docker.distribution.manifest.v2+json" in workflow
+    assert "observed media type:" in workflow
+    assert "Linux platforms:" in workflow
     assert "/opt/heartwood-vllm/bin/python" in workflow
     assert "find" in workflow
     assert "-size +10M" in workflow


### PR DESCRIPTION
### :recycle: Current Situation & Problem

The protected `0.1.0` release gate correctly rejected the immutable Terra GPU candidate because it was published as an OCI index. Terra's Leonardo image detection requires the platform image variants to use a single Docker schema-2 manifest, matching the existing Terra CPU contract.

### :gear: Release Notes

- Disable Buildx default attestations for immutable GPU candidates so the Terra GPU variant can be flattened to one image manifest.
- Validate the immutable Terra GPU tag's Docker schema-2 media type during main publication.
- Retain the AMD64 OCI-index contract for the generic GPU image.
- Report the exact candidate and expected media shape when release verification fails.

### :books: Documentation

No documentation change is required. This enforces the existing documented Terra image compatibility contract for the GPU variant.

### :white_check_mark: Testing

- 41 focused container and release-governance tests pass.
- Actionlint, yamllint, Bash syntax, Ruff, and whitespace checks pass locally.
- The verifier reproduces the current failure and identifies only the immutable Terra GPU candidate as incompatible.

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
