### PR TITLE
Prepare the 0.2.0 Beta Prerelease

### DIFF
--- a/VERSION.toml
+++ b/VERSION.toml
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 # SPDX-License-Identifier: MIT
 
-version = "0.2.0"
+version = "0.2.0-beta.1"

--- a/deploy/verify_release_candidate.py
+++ b/deploy/verify_release_candidate.py
@@ -163,6 +163,7 @@ def check_status(
 
 def source_version_errors(root: Path, version: str) -> list[str]:
     """Return packaged components whose source metadata differs from version."""
+    errors: list[str] = []
     semantic_versions: dict[str, str] = {}
     python_source_versions: dict[str, str] = {}
     python_lock_versions: dict[str, str] = {}
@@ -190,12 +191,15 @@ def source_version_errors(root: Path, version: str) -> list[str]:
     ):
         for metadata_path in sorted(skill_root.glob("*/metadata.json")):
             skill_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-            if isinstance(skill_metadata, dict) and isinstance(
-                skill_metadata.get("heartwood.version"), str
-            ):
-                semantic_versions[str(metadata_path.relative_to(root))] = skill_metadata[
-                    "heartwood.version"
-                ]
+            relative_path = str(metadata_path.relative_to(root))
+            if not isinstance(skill_metadata, dict):
+                errors.append(f"{relative_path}: expected a JSON object")
+                continue
+            skill_version = skill_metadata.get("heartwood.version")
+            if not isinstance(skill_version, str):
+                errors.append(f"{relative_path}: heartwood.version must be a string")
+                continue
+            semantic_versions[relative_path] = skill_version
     web_lock_path = root / "packages" / "webui" / "package-lock.json"
     web_lock = json.loads(web_lock_path.read_text(encoding="utf-8"))
     if isinstance(web_lock, dict):
@@ -225,11 +229,12 @@ def source_version_errors(root: Path, version: str) -> list[str]:
             ):
                 python_lock_versions[f"uv.lock:{name}"] = package_version
     if not semantic_versions and not python_source_versions and not python_lock_versions:
-        return ["no packaged component versions were found"]
+        errors.append("no packaged component versions were found")
+        return errors
     observed_source_versions = semantic_versions | python_source_versions
-    errors = [
+    errors.extend(
         f"{path}: {found}" for path, found in observed_source_versions.items() if found != version
-    ]
+    )
     errors.extend(
         f"{path}: {found} (expected Python version {expected_python_version})"
         for path, found in python_lock_versions.items()

--- a/deploy/verify_release_candidate.py
+++ b/deploy/verify_release_candidate.py
@@ -184,6 +184,18 @@ def source_version_errors(root: Path, version: str) -> list[str]:
     web_metadata = json.loads(web_path.read_text(encoding="utf-8"))
     if isinstance(web_metadata, dict) and isinstance(web_metadata.get("version"), str):
         semantic_versions[str(web_path.relative_to(root))] = web_metadata["version"]
+    for skill_root in (
+        root / "skills" / "verified",
+        root / "fixtures" / "synthetic" / "skills",
+    ):
+        for metadata_path in sorted(skill_root.glob("*/metadata.json")):
+            skill_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            if isinstance(skill_metadata, dict) and isinstance(
+                skill_metadata.get("heartwood.version"), str
+            ):
+                semantic_versions[str(metadata_path.relative_to(root))] = skill_metadata[
+                    "heartwood.version"
+                ]
     web_lock_path = root / "packages" / "webui" / "package-lock.json"
     web_lock = json.loads(web_lock_path.read_text(encoding="utf-8"))
     if isinstance(web_lock, dict):

--- a/docs/carina-cli.md
+++ b/docs/carina-cli.md
@@ -33,19 +33,19 @@ cd "$PROJECT"
 
 Keep the project separate from the installation root. Heartwood will create `.heartwood/` in the current directory; no state or model paths need to be exported.
 
-## Install Release 0.2.0
+## Install Release 0.2.0-beta.1
 
 Load Carina's supported package manager and download the immutable installer:
 
 ```bash
 module load micromamba/2.3.3
 curl --fail --location --remote-name \
-  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0/heartwood-installer
+  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.1/heartwood-installer
 chmod +x heartwood-installer
 ./heartwood-installer \
   --root "$INSTALL_ROOT" \
   --platform carina \
-  --version 0.2.0
+  --version 0.2.0-beta.1
 export PATH="$INSTALL_ROOT/bin:$PATH"
 ```
 

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -18,10 +18,10 @@ Use the Terra-derived image when Terra must retain ownership of Jupyter, the not
 
 | Image | Platforms | Purpose |
 |---|---|---|
-| `ghcr.io/schmiedmayerlab/heartwood:0.2.0` | AMD64 and ARM64 | Stable generic runtime and the normal container starting point. |
-| `ghcr.io/schmiedmayerlab/heartwood:0.2.0-gpu-nvidia` | AMD64 | Generic runtime with an isolated vLLM environment for compatible NVIDIA deployments. |
-| `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra` | AMD64 | Terra Jupyter base with the Heartwood payload added. |
-| `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra-gpu-nvidia` | AMD64 | Terra-derived image with the isolated vLLM environment. |
+| `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1` | AMD64 and ARM64 | Versioned generic runtime and the normal container starting point. |
+| `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1-gpu-nvidia` | AMD64 | Generic runtime with an isolated vLLM environment for compatible NVIDIA deployments. |
+| `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1-terra` | AMD64 | Terra Jupyter base with the Heartwood payload added. |
+| `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1-terra-gpu-nvidia` | AMD64 | Terra-derived image with the isolated vLLM environment. |
 | `edge` and `edge-*` | Flavor-specific | Latest validated `main` build for development, not a stable release. |
 | `sha-<git-sha>` and `sha-<git-sha>-*` | Flavor-specific | Immutable images for one repository commit. |
 
@@ -38,7 +38,7 @@ cd heartwood-demo
 docker run --rm -it \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood serve --host 0.0.0.0
 ```
 
@@ -53,7 +53,7 @@ The same project can use the terminal interface instead:
 ```bash
 docker run --rm -it \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood
 ```
 
@@ -72,12 +72,12 @@ List the current recommendations, then download one into the project's `.heartwo
 ```bash
 docker run --rm -it \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood models local
 
 docker run --rm -it \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood models download qwen25-7b-instruct-q4_k_m
 ```
 
@@ -86,12 +86,12 @@ You can instead inspect and prepare another Hugging Face model. The image choose
 ```bash
 docker run --rm -it \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood models inspect <owner/model>
 
 docker run --rm -it \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood models download <owner/model>
 ```
 
@@ -103,7 +103,7 @@ Start the model and browser together:
 docker run --rm -it \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood launch --web --host 0.0.0.0
 ```
 
@@ -113,7 +113,7 @@ For a no-network terminal demonstration after the artifact is present:
 docker run --rm -it \
   --network none \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood launch --plain
 ```
 

--- a/docs/getting-started-offline.md
+++ b/docs/getting-started-offline.md
@@ -158,7 +158,7 @@ docker volume create heartwood-project
 
 docker run --rm -it \
   -v heartwood-project:/workspace \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood models download qwen25-7b-instruct-q4_k_m
 ```
 
@@ -168,7 +168,7 @@ Then start a terminal session with container networking disabled:
 docker run --rm -it \
   --network none \
   -v heartwood-project:/workspace \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1 \
   heartwood launch --plain
 ```
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
 
 # Platform Support and Validation
 
-This page records the evidence available for release `0.2.0`. Start with [Choose Where to Run Heartwood](platforms.md) when deciding which setup to use; this page is the detailed reference for operators and reviewers.
+This page records the evidence available for release `0.2.0-beta.1`. Start with [Choose Where to Run Heartwood](platforms.md) when deciding which setup to use; this page is the detailed reference for operators and reviewers.
 
 An implemented feature, automated test, or published artifact is not evidence of institutional approval. The [Documentation Guide](README.md#documentation-status) defines each status term, and [Platform Architecture](../design/02-platforms.md) explains the underlying deployment assumptions.
 
@@ -28,13 +28,13 @@ No listed path is automatically approved for protected health information or ano
 
 ### Generic Container
 
-The published tags are `0.2.0`, `edge`, and immutable `sha-<git-sha>` tags. Continuous integration builds native AMD64 and ARM64 artifacts and checks the no-weight image contract, centrally recommended and user-selected model planning, OpenHands loopback conversation, grouped action confirmation, mounted llama.cpp inference, one-project-volume recovery, browser workflow, audit export, CLI replay, responsive browser layout, and notebook-proxy behavior.
+The published tags are `0.2.0-beta.1`, `edge`, and immutable `sha-<git-sha>` tags. Continuous integration builds native AMD64 and ARM64 artifacts and checks the no-weight image contract, centrally recommended and user-selected model planning, OpenHands loopback conversation, grouped action confirmation, mounted llama.cpp inference, one-project-volume recovery, browser workflow, audit export, CLI replay, responsive browser layout, and notebook-proxy behavior.
 
 These checks use synthetic fixtures. A self-hosted deployment must still validate the exact host, identity, storage, network, provider, model, and data-use controls.
 
 ### Terra
 
-The published tags are `0.2.0-terra`, `edge-terra`, and immutable `sha-<git-sha>-terra` tags. Terra tags use the single-platform Docker schema-2 format required by Leonardo.
+The published tags are `0.2.0-beta.1-terra`, `edge-terra`, and immutable `sha-<git-sha>-terra` tags. Terra tags use the single-platform Docker schema-2 format required by Leonardo.
 
 Continuous integration builds from the real pinned Terra base on `main` and checks the Jupyter environment, Heartwood kernel, inherited entrypoint, notebook route, Leonardo-compatible manifest, arbitrary current-directory project isolation, restart persistence, Heartwood browser and readiness routes through Jupyter Server Proxy, shared local-model contract, OpenHands synthetic workflow, mounted llama.cpp inference, CLI, notebook bridge, and audit export.
 
@@ -42,7 +42,7 @@ Real Terra workspace validation remains required before a supported or instituti
 
 ### Stanford Carina
 
-Release `0.2.0` provides the native installation bundle; no Carina-specific container image is published. Continuous integration verifies the installer layout, locked Heartwood and vLLM environments, Micromamba and FFmpeg bootstrap, Slurm handoff, exact current-directory project preservation, runtime supervision, setup, session lifecycle, shutdown, scratch cleanup, recommended and user-selected model planning, verified download, GPU-partition discovery, explicit compute consent, grouped OpenHands confirmation, narrow-terminal interaction, Stanford AI API Gateway connection, and both permitted confirmation modes.
+Release `0.2.0-beta.1` provides the native installation bundle; no Carina-specific container image is published. Continuous integration verifies the installer layout, locked Heartwood and vLLM environments, Micromamba and FFmpeg bootstrap, Slurm handoff, exact current-directory project preservation, runtime supervision, setup, session lifecycle, shutdown, scratch cleanup, recommended and user-selected model planning, verified download, GPU-partition discovery, explicit compute consent, grouped OpenHands confirmation, narrow-terminal interaction, Stanford AI API Gateway connection, and both permitted confirmation modes.
 
 The published release has not completed the documented synthetic workflow on Carina. The current supported presentation is the terminal; no authenticated browser-proxy route or controlled-data approval is claimed.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -19,7 +19,7 @@ Heartwood releases use Semantic Versioning without a `v` prefix. Examples includ
 Start the protected workflow from the current `main` branch:
 
 ```bash
-gh workflow run create-release.yml --ref main -f version=0.2.0
+gh workflow run create-release.yml --ref main -f version=0.2.0-beta.1
 ```
 
 Every `main` commit runs the `Main Validation` workflow. Its dependency graph calls the repository validation, CodeQL, Python, web, secret scan, container smoke, native asset, CPU image, and GPU image workflows and emits `Release Candidate Ready` only after every dependency succeeds. The release workflow accepts only strict Semantic Versioning, requires every packaged source version to match, refuses an existing tag or published release, and binds the candidate to the current `main` commit. It checks `Release Candidate Ready` once for that exact commit and fails immediately when main validation is absent, incomplete, skipped, cancelled, or failed. It then verifies the immutable generic, Terra, generic GPU, and Terra GPU images and rebuilds and tests the versioned native installation bundle.

--- a/docs/terra-jupyter-demo.ipynb
+++ b/docs/terra-jupyter-demo.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook is part of the Heartwood open-source project. Copyright and license metadata are declared in `REUSE.toml`.\n",
     "\n",
-    "This notebook exercises the synthetic Heartwood reference analysis in a Terra-style Jupyter project. It uses the same persisted session as the CLI and browser interface, keeps all data synthetic, and does not claim real Terra identity binding, BigQuery access, controlled-data validation, or institutional approval. Use the no-weight `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra` release image documented in `docs/terra-jupyter-demo.md`.\n"
+    "This notebook exercises the synthetic Heartwood reference analysis in a Terra-style Jupyter project. It uses the same persisted session as the CLI and browser interface, keeps all data synthetic, and does not claim real Terra identity binding, BigQuery access, controlled-data validation, or institutional approval. Use the no-weight `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1-terra` release image documented in `docs/terra-jupyter-demo.md`.\n"
    ]
   },
   {

--- a/docs/terra-jupyter-demo.md
+++ b/docs/terra-jupyter-demo.md
@@ -25,7 +25,7 @@ Terra keeps `/home/jupyter` on the persistent disk. Create a separate analysis d
 Use the immutable release image:
 
 ```text
-ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra
+ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1-terra
 ```
 
 Create a Terra workspace containing no protected health information, select the custom image, and start Jupyter. Confirm that:
@@ -87,7 +87,7 @@ heartwood launch --web
 
 The portable Terra image chooses a supported single-file GGUF model for its CPU llama.cpp runtime. Heartwood resolves the repository to an immutable revision, displays estimated storage and memory requirements, downloads it into the current project's `.heartwood/models/` directory, verifies it, and persists the shared selection. The launcher supervises both the model and browser interface. First inference on CPU can be slow, and attaching a GPU does not accelerate this portable image's llama.cpp path.
 
-The explicit Terra GPU image is `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra-gpu-nvidia`. It contains the pinned vLLM runtime but still contains no model weights. In that image, Heartwood prefers a supported standard Hugging Face snapshot and reports approximate GPU-memory requirements. GPU selection, model suitability, and live platform validation must match the deployment evidence before it replaces the CPU path.
+The explicit Terra GPU image is `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.1-terra-gpu-nvidia`. It contains the pinned vLLM runtime but still contains no model weights. In that image, Heartwood prefers a supported standard Hugging Face snapshot and reports approximate GPU-memory requirements. GPU selection, model suitability, and live platform validation must match the deployment evidence before it replaces the CPU path.
 
 ## Open the Browser Interface
 

--- a/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
+++ b/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0"
+  heartwood.version: "0.2.0-beta.1"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
+++ b/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0",
+  "heartwood.version": "0.2.0-beta.1",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/packages/adapters/pyproject.toml
+++ b/packages/adapters/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-adapters"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Adapter service provider interfaces and conformance checks for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/adapters/src/heartwood/adapters/__init__.py
+++ b/packages/adapters/src/heartwood/adapters/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "assert_registry_adapter_conforms",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/adapters/src/heartwood/adapters/conformance.py
+++ b/packages/adapters/src/heartwood/adapters/conformance.py
@@ -59,7 +59,7 @@ def assert_data_source_adapter_conforms(
 def assert_registry_adapter_conforms(
     adapter: RegistryAdapter,
     skill_id: str = "heartwood.synthetic.omop-summary",
-    version: str = "0.2.0",
+    version: str = "0.2.0-beta.1",
 ) -> None:
     """Assert the shared minimum contract for registry adapters."""
     assert adapter.registry_id

--- a/packages/adapters/tests/test_conformance.py
+++ b/packages/adapters/tests/test_conformance.py
@@ -102,7 +102,7 @@ class FakeRegistryAdapter:
     def verify_skill(self, reference: SkillReference) -> RegistryVerification:
         """Verify the synthetic skill reference."""
         return RegistryVerification(
-            verified=reference.version == "0.2.0",
+            verified=reference.version == "0.2.0-beta.1",
             reason="synthetic fixture registry result",
         )
 

--- a/packages/audit/pyproject.toml
+++ b/packages/audit/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-audit"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Hash-chained audit logging for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/audit/src/heartwood/audit/__init__.py
+++ b/packages/audit/src/heartwood/audit/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "scrub_json_value",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-cli"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "The heartwood command-line interface — the primary interaction surface."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/cli/src/heartwood/cli/__init__.py
+++ b/packages/cli/src/heartwood/cli/__init__.py
@@ -65,7 +65,7 @@ from heartwood.session import (
 
 __all__ = ["__version__", "main"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"
 
 _PROG = "heartwood"
 

--- a/packages/compliance/pyproject.toml
+++ b/packages/compliance/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-compliance"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Synthetic-only reviewer packet and audit bundle generation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/compliance/src/heartwood/compliance/__init__.py
+++ b/packages/compliance/src/heartwood/compliance/__init__.py
@@ -12,4 +12,4 @@ from heartwood.compliance._reviewer_packet import ReviewerPacket, ReviewerPacket
 
 __all__ = ["ReviewerPacket", "ReviewerPacketGenerator", "__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -150,6 +150,13 @@ def test_prerelease_sources_use_semver_and_python_lock_uses_pep440(
         f'{{"version": "{version}", "packages": {{"": {{"version": "{version}"}}}}}}\n',
         encoding="utf-8",
     )
+    skill = tmp_path / "skills" / "verified" / "example"
+    skill.mkdir(parents=True)
+    skill_metadata = skill / "metadata.json"
+    skill_metadata.write_text(
+        f'{{"heartwood.version": "{version}"}}\n',
+        encoding="utf-8",
+    )
     (tmp_path / "uv.lock").write_text(
         '[[package]]\nname = "heartwood-cli"\nversion = "0.2.0b1"\n',
         encoding="utf-8",
@@ -167,6 +174,12 @@ def test_prerelease_sources_use_semver_and_python_lock_uses_pep440(
         (docs / name).write_text(content, encoding="utf-8")
 
     assert _release_verifier().source_version_errors(tmp_path, version) == []
+
+    skill_metadata.write_text('{"heartwood.version": "0.2.0-beta.2"}\n', encoding="utf-8")
+    assert (
+        "skills/verified/example/metadata.json: 0.2.0-beta.2"
+        in _release_verifier().source_version_errors(tmp_path, version)
+    )
 
 
 def test_main_validation_owns_release_readiness_dependencies() -> None:

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -181,6 +181,24 @@ def test_prerelease_sources_use_semver_and_python_lock_uses_pep440(
         in _release_verifier().source_version_errors(tmp_path, version)
     )
 
+    skill_metadata.write_text("{}\n", encoding="utf-8")
+    assert (
+        "skills/verified/example/metadata.json: heartwood.version must be a string"
+        in _release_verifier().source_version_errors(tmp_path, version)
+    )
+
+    skill_metadata.write_text('{"heartwood.version": 2}\n', encoding="utf-8")
+    assert (
+        "skills/verified/example/metadata.json: heartwood.version must be a string"
+        in _release_verifier().source_version_errors(tmp_path, version)
+    )
+
+    skill_metadata.write_text("[]\n", encoding="utf-8")
+    assert (
+        "skills/verified/example/metadata.json: expected a JSON object"
+        in _release_verifier().source_version_errors(tmp_path, version)
+    )
+
 
 def test_main_validation_owns_release_readiness_dependencies() -> None:
     workflow = Path(".github/workflows/main-validation.yml").read_text(encoding="utf-8")

--- a/packages/core-adapter/pyproject.toml
+++ b/packages/core-adapter/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-core-adapter"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Core harness orchestration for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/core-adapter/src/heartwood/core_adapter/__init__.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/detector/pyproject.toml
+++ b/packages/detector/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-detector"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Deterministic, propose-not-commit environment and dataset detection for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/detector/src/heartwood/detector/__init__.py
+++ b/packages/detector/src/heartwood/detector/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "platform_detection_evidence",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/fixtures/pyproject.toml
+++ b/packages/fixtures/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-fixtures"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Synthetic fixture linting for Heartwood tests and replay artifacts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/fixtures/src/heartwood/fixtures/__init__.py
+++ b/packages/fixtures/src/heartwood/fixtures/__init__.py
@@ -12,4 +12,4 @@ from heartwood.fixtures.lint import FixtureFinding, lint_fixture_tree, main
 
 __all__ = ["FixtureFinding", "__version__", "lint_fixture_tree", "main"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/gateway/pyproject.toml
+++ b/packages/gateway/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-gateway"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Session gateway for Heartwood command and event streams."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/pyproject.toml
+++ b/packages/model-policy/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-model-policy"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Deny-by-default model-call policy evaluation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/src/heartwood/model_policy/__init__.py
+++ b/packages/model-policy/src/heartwood/model_policy/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "normalize_endpoint",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/notebook/pyproject.toml
+++ b/packages/notebook/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-notebook"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Notebook-facing Python API and widget bridge for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/notebook/src/heartwood/notebook/__init__.py
+++ b/packages/notebook/src/heartwood/notebook/__init__.py
@@ -43,4 +43,4 @@ __all__ = [
     "render_widgets",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/schemas/pyproject.toml
+++ b/packages/schemas/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-schemas"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Versioned typed schemas for Heartwood policy, audit, detection, and skill metadata records."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/schemas/src/heartwood/schemas/__init__.py
+++ b/packages/schemas/src/heartwood/schemas/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "schema_names",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/schemas/src/heartwood/schemas/_records.py
+++ b/packages/schemas/src/heartwood/schemas/_records.py
@@ -14,6 +14,14 @@ from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
 
+_SEMVER_PATTERN = (
+    r"^(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
 __all__ = [
     "ActionConfirmationMode",
     "ApprovalRecord",
@@ -132,7 +140,7 @@ class SkillMetadata(_HeartwoodRecord):
         alias="heartwood.trust-tier"
     )
     requires_network: bool = Field(alias="heartwood.requires-network")
-    version: str = Field(alias="heartwood.version", min_length=1, pattern=r"^\d+\.\d+\.\d+$")
+    version: str = Field(alias="heartwood.version", min_length=1, pattern=_SEMVER_PATTERN)
     signature: str | None = Field(default=None, alias="heartwood.sig")
 
     @field_validator("dataset_types", "platforms", mode="before")
@@ -153,6 +161,19 @@ class SkillMetadata(_HeartwoodRecord):
                 return True
             if lowered == "false":
                 return False
+        return value
+
+    @field_validator("version")
+    @classmethod
+    def _reject_leading_zero_prerelease_identifiers(cls, value: str) -> str:
+        """Enforce the numeric prerelease rule from Semantic Versioning."""
+        prerelease = value.split("+", maxsplit=1)[0].partition("-")[2]
+        if prerelease and any(
+            identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0")
+            for identifier in prerelease.split(".")
+        ):
+            msg = "numeric Semantic Versioning prerelease identifiers cannot have leading zeroes"
+            raise ValueError(msg)
         return value
 
     @model_validator(mode="after")

--- a/packages/schemas/tests/test_schema_records.py
+++ b/packages/schemas/tests/test_schema_records.py
@@ -159,13 +159,40 @@ def test_skill_metadata_accepts_skill_md_aliases() -> None:
             "heartwood.phi-risk": "none",
             "heartwood.trust-tier": "verified",
             "heartwood.requires-network": "false",
-            "heartwood.version": "0.1.0",
+            "heartwood.version": "0.2.0-beta.1",
             "heartwood.sig": "sigstore:synthetic-bundle",
         }
     )
     assert metadata.dataset_types == ("omop-cdm", "fhir")
     assert metadata.platforms == ("generic", "terra")
     assert metadata.requires_network is False
+    assert metadata.version == "0.2.0-beta.1"
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "01.2.3",
+        "1.02.3",
+        "1.2.03",
+        "1.2.3-01",
+        "1.2.3-beta.01",
+        "1.2",
+        "v1.2.3",
+    ],
+)
+def test_skill_metadata_rejects_invalid_semantic_versions(version: str) -> None:
+    with pytest.raises(ValidationError):
+        SkillMetadata.model_validate(
+            {
+                "heartwood.dataset-types": "omop-cdm",
+                "heartwood.platforms": "generic",
+                "heartwood.phi-risk": "none",
+                "heartwood.trust-tier": "community",
+                "heartwood.requires-network": "false",
+                "heartwood.version": version,
+            }
+        )
 
 
 def test_verified_skill_metadata_requires_signature() -> None:

--- a/packages/session/pyproject.toml
+++ b/packages/session/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-session"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Shared session command/event contract for Heartwood interfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/session/src/heartwood/session/__init__.py
+++ b/packages/session/src/heartwood/session/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "validate_session_id",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.0-beta.1"

--- a/packages/skills/pyproject.toml
+++ b/packages/skills/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-skills"
-version = "0.2.0"
+version = "0.2.0-beta.1"
 description = "Local SKILL.md verification and deterministic skill test harnesses for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/webui/package-lock.json
+++ b/packages/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0",
+  "version": "0.2.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heartwood/webui",
-      "version": "0.2.0",
+      "version": "0.2.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@stanfordspezi/spezi-web-design-system": "0.20.0",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0",
+  "version": "0.2.0-beta.1",
   "private": true,
   "type": "module",
   "description": "Researcher web UI for Heartwood sessions.",

--- a/skills/verified/aggregate-export/SKILL.md
+++ b/skills/verified/aggregate-export/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0"
+  heartwood.version: "0.2.0-beta.1"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/aggregate-export/metadata.json
+++ b/skills/verified/aggregate-export/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0",
+  "heartwood.version": "0.2.0-beta.1",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/baseline-model/SKILL.md
+++ b/skills/verified/baseline-model/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0"
+  heartwood.version: "0.2.0-beta.1"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/baseline-model/metadata.json
+++ b/skills/verified/baseline-model/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0",
+  "heartwood.version": "0.2.0-beta.1",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/omop-cohort-summary/SKILL.md
+++ b/skills/verified/omop-cohort-summary/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0"
+  heartwood.version: "0.2.0-beta.1"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/omop-cohort-summary/metadata.json
+++ b/skills/verified/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0",
+  "heartwood.version": "0.2.0-beta.1",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1469,7 +1469,7 @@ wheels = [
 
 [[package]]
 name = "heartwood-adapters"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/adapters" }
 dependencies = [
     { name = "heartwood-detector" },
@@ -1486,7 +1486,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-audit"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/audit" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1497,7 +1497,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-cli"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/cli" }
 dependencies = [
     { name = "heartwood-compliance" },
@@ -1518,7 +1518,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-compliance"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/compliance" }
 dependencies = [
     { name = "heartwood-audit" },
@@ -1533,7 +1533,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-core-adapter"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/core-adapter" }
 dependencies = [
     { name = "heartwood-adapters" },
@@ -1554,7 +1554,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-detector"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/detector" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1565,12 +1565,12 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-fixtures"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/fixtures" }
 
 [[package]]
 name = "heartwood-gateway"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/gateway" }
 dependencies = [
     { name = "anthropic" },
@@ -1612,7 +1612,7 @@ provides-extras = ["agent"]
 
 [[package]]
 name = "heartwood-model-policy"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/model-policy" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1623,7 +1623,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-notebook"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/notebook" }
 dependencies = [
     { name = "heartwood-gateway" },
@@ -1647,7 +1647,7 @@ provides-extras = ["widgets"]
 
 [[package]]
 name = "heartwood-schemas"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/schemas" }
 dependencies = [
     { name = "pydantic" },
@@ -1658,7 +1658,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-session"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/session" }
 dependencies = [
     { name = "pydantic" },
@@ -1669,7 +1669,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-skills"
-version = "0.2.0"
+version = "0.2.0b1"
 source = { editable = "packages/skills" }
 dependencies = [
     { name = "heartwood-schemas" },


### PR DESCRIPTION
### ♻️ Current Situation & Problem

The protected release workflow requires the requested tag to match every packaged source version on `main`. The merged source still declared `0.2.0`, so `0.2.0-beta.1` could not be published without a reviewed version-preparation change. Local validation also identified that Skill metadata accepted stable versions only and rejected the prerelease identifier.

### ⚙️ Release Notes

- Prepare Heartwood `0.2.0-beta.1` across Python packages, the web package, bundled Skills, release guides, and lockfiles.
- Accept strict Semantic Versioning prerelease and build identifiers in the shared Skill metadata schema.
- Include bundled and synthetic Skill metadata in the release source-version gate.

### 📚 Documentation

The versioned container, Terra, Carina, offline, and release examples now reference `0.2.0-beta.1`. The stable documentation recovery example remains stable-only because prereleases do not replace the public GitHub Pages site.

### ✅ Testing

- `python3 deploy/verify_release_candidate.py --version 0.2.0-beta.1 --source-root . --version-only`
- `uv lock --check`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy packages`
- `uv run pytest --cov-report=term-missing` (`586` tests; `90.24%` coverage)
- Web formatting, linting, type checking, unit coverage, production build, and license checks
- `uv run --no-sync zensical build --clean --strict`
- Clean npm installation from `package-lock.json`

### Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
