### PR TITLE
Fix Versioned Documentation Publication

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -131,6 +131,7 @@ jobs:
             --branch "${DOCUMENTATION_BRANCH}" \
             --remote origin
       - name: Stage the complete Pages artifact
+        id: version_store
         env:
           DOCUMENTATION_CHANNEL: ${{ steps.release.outputs.channel }}
           RELEASE_VERSION: ${{ inputs.version }}
@@ -145,6 +146,9 @@ jobs:
             --arg version "${RELEASE_VERSION}" \
             'any(.[]; .version == $version and (.aliases | index($channel)) != null)' \
             published-site/versions.json
+          printf 'commit=%s\n' \
+            "$(git rev-parse --verify "${DOCUMENTATION_BRANCH}^{commit}")" \
+            >> "${GITHUB_OUTPUT}"
       - name: Enable version store authentication
         uses: actions/checkout@v7
         with:
@@ -153,9 +157,11 @@ jobs:
           clean: false
           persist-credentials: true
       - name: Push the validated version store
+        env:
+          DOCUMENTATION_COMMIT: ${{ steps.version_store.outputs.commit }}
         run: >-
           git -c core.hooksPath=/dev/null push -- origin
-          "refs/heads/${DOCUMENTATION_BRANCH}:refs/heads/${DOCUMENTATION_BRANCH}"
+          "${DOCUMENTATION_COMMIT}:refs/heads/${DOCUMENTATION_BRANCH}"
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/deploy/tests/versioned_documentation_smoke.sh
+++ b/deploy/tests/versioned_documentation_smoke.sh
@@ -12,6 +12,7 @@ repository_root="$(git rev-parse --show-toplevel)"
 publisher="${repository_root}/deploy/publish-versioned-documentation.sh"
 stable_branch="heartwood-documentation-stable-smoke-$$"
 preview_branch="heartwood-documentation-preview-smoke-$$"
+handoff_branch="heartwood-documentation-handoff-smoke-$$"
 remote_name="heartwood-documentation-smoke-$$"
 remote_root="$(mktemp -d)"
 remote_repository="${remote_root}/pages.git"
@@ -126,6 +127,13 @@ git --git-dir="${remote_repository}" show \
   "refs/heads/${preview_branch}:0.2.0-beta.1/index.html" >/dev/null
 git --git-dir="${remote_repository}" show \
   "refs/heads/${preview_branch}:preview/index.html" | grep --fixed-strings '../0.2.0-beta.2/' >/dev/null
+version_store_commit="$(git rev-parse "refs/heads/${preview_branch}^{commit}")"
+git update-ref -d "refs/heads/${preview_branch}"
+git push -- "${remote_name}" \
+  "${version_store_commit}:refs/heads/${handoff_branch}"
+git --git-dir="${remote_repository}" show \
+  "refs/heads/${handoff_branch}:preview/index.html" | grep --fixed-strings '../0.2.0-beta.2/' >/dev/null
+git update-ref "refs/heads/${preview_branch}" "${version_store_commit}"
 
 for branch in "${stable_branch}" "${preview_branch}"; do
   git show "${branch}:.nojekyll" >/dev/null

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -265,12 +265,13 @@ def test_documentation_is_validated_continuously_and_published_from_releases() -
     assert 'channel="preview"' in publication
     assert 'channel="stable"' in publication
     assert "DOCUMENTATION_BRANCH: gh-pages" in publication
-    assert "refs/heads/${DOCUMENTATION_BRANCH}:refs/heads/${DOCUMENTATION_BRANCH}" in publication
+    assert "${DOCUMENTATION_COMMIT}:refs/heads/${DOCUMENTATION_BRANCH}" in publication
     assert "deploy/publish-versioned-documentation.sh" in publication
     assert "${RUNNER_TEMP}/verify_release_candidate.py" in publication
     assert 'python3 "${RUNNER_TEMP}/verify_release_candidate.py"' in publication
     assert "published-site/${RELEASE_VERSION}/index.html" in publication
     assert "published-site/${DOCUMENTATION_CHANNEL}/index.html" in publication
+    assert 'git rev-parse --verify "${DOCUMENTATION_BRANCH}^{commit}"' in publication
     assert "actions/upload-pages-artifact@v5" in publication
     assert "actions/deploy-pages@v5" in publication
     assert "Verify the deployed documentation" in publication
@@ -296,6 +297,7 @@ def test_documentation_is_validated_continuously_and_published_from_releases() -
     assert "persist-credentials: false" in publication[release_checkout:release_verification]
     assert release_checkout < release_verification < artifact_validation < authentication < push
     assert "persist-credentials: true" in publication[authentication:push]
+    assert "DOCUMENTATION_COMMIT: ${{ steps.version_store.outputs.commit }}" in publication
     assert "prerelease: ${{ steps.release.outputs.prerelease }}" in release
     assert "--print-prerelease" in release
     assert "release_flags=(--draft --latest=false)" in release


### PR DESCRIPTION
### :recycle: Current Situation & Problem
Follow-up to #58. The one-time `0.2.0-beta.1` documentation backfill built and validated the complete Pages artifact, but its authenticated checkout removed the temporary `gh-pages` branch before the final push. The workflow therefore failed with `src refspec refs/heads/gh-pages does not match any`.

### :gear: Release Notes
- Publish the validated documentation commit even when the credential handoff removes its local branch reference.
- Exercise the credential-handoff failure condition in the versioned documentation smoke test.

### :books: Documentation
No user-facing documentation changes are required. This PR corrects the release documentation publication workflow introduced in #58.

### :white_check_mark: Testing
- Full Python test suite: 586 passed with 90.24% coverage.
- Release governance tests: 42 passed.
- Versioned documentation smoke test passes after deleting the source branch before publication.
- ShellCheck, actionlint, yamllint, Ruff, mypy, strict documentation build, and `git diff --check` pass.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).