### PR TITLE
Align Terra Publication Proxy Metadata

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -333,6 +333,7 @@ jobs:
           docker run --rm --platform linux/amd64
           --volume heartwood-terra-managed-project:/home/jupyter
           --env GOOGLE_PROJECT=heartwood-ci
+          --env CLUSTER_NAME=terra-managed-launch-smoke
           --env WORKSPACE_ID=terra-managed-launch-smoke
           --entrypoint bash
           "${CANDIDATE_REFERENCE}"
@@ -347,6 +348,7 @@ jobs:
           --workdir /home/jupyter/model-analysis --entrypoint bash
           --volume heartwood-terra-managed-project:/home/jupyter
           --env GOOGLE_PROJECT=heartwood-ci
+          --env CLUSTER_NAME=terra-managed-launch-smoke
           --env WORKSPACE_ID=terra-managed-launch-smoke
           "${CANDIDATE_REFERENCE}"
           /opt/heartwood/images/platform/scripts/terra_managed_launch_smoke.sh

--- a/deploy/tests/versioned_documentation_smoke.sh
+++ b/deploy/tests/versioned_documentation_smoke.sh
@@ -31,7 +31,13 @@ cleanup() {
   git remote remove "${remote_name}" 2>/dev/null || true
   git update-ref -d "refs/heads/${stable_branch}" || true
   git update-ref -d "refs/heads/${preview_branch}" || true
-  rm -rf "${remote_root}"
+  for _ in 1 2 3; do
+    rm -rf "${remote_root}" 2>/dev/null && break
+    sleep 0.1
+  done
+  if [[ -e "${remote_root}" ]]; then
+    echo "warning: could not remove temporary documentation remote: ${remote_root}" >&2
+  fi
 }
 trap cleanup EXIT
 
@@ -105,6 +111,8 @@ git show "${stable_branch}:versions.json" | jq --exit-status '
 ' >/dev/null
 
 git init --bare --quiet "${remote_repository}"
+git --git-dir="${remote_repository}" config gc.auto 0
+git --git-dir="${remote_repository}" config maintenance.auto false
 git remote add "${remote_name}" "${remote_repository}"
 bash "${publisher}" \
   --version 0.2.0-beta.1 \

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -765,6 +765,8 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
     assert "container_persistence_smoke.sh" in smoke
     assert "Verify host-user bind-mount persistence" in smoke
     assert "bind_mount_user_smoke.sh" in smoke
+    assert publish.count("--env CLUSTER_NAME=terra-managed-launch-smoke") == 2
+    assert smoke.count("--env CLUSTER_NAME=terra-managed-launch-smoke") == 2
     assert "Download and verify CI-only model fixture" in smoke
     assert "heartwood models download llama-cpp-stories260k-ci" in smoke
     assert "--volume heartwood-ci-project:/workspace" in smoke


### PR DESCRIPTION
### :recycle: Current Situation & Problem

The `0.2.0-beta.2` release candidate is blocked because the main-only staged Terra managed-model smoke supplies `WORKSPACE_ID` but not `CLUSTER_NAME`. Heartwood therefore starts successfully but correctly declines to print an authenticated Jupyter proxy path, causing the publication job and `Release Candidate Ready` gate to fail.

Pull-request Terra smoke already supplies both values. The mismatch remained isolated to the main-only image publication path, which does not run on pull requests.

### :gear: Release Notes

- Supply `CLUSTER_NAME=terra-managed-launch-smoke` while preparing and launching the staged Terra managed-model candidate.
- Require the pull-request and publication workflows to contain the same two authenticated-proxy cluster bindings.

### :books: Documentation

No user-facing documentation changes are required. The existing Terra instructions already describe the `GOOGLE_PROJECT` and `CLUSTER_NAME` proxy contract accurately.

### :white_check_mark: Testing

- Actionlint passes for the updated publication workflow.
- YAML lint passes for the updated publication workflow.
- All 21 container-asset compliance tests pass.
- `git diff --check` passes.

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
