### PR TITLE
Reclaim GPU Candidate Verification Space

### DIFF
--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -272,6 +272,10 @@ jobs:
           digest="$(python3 images/scripts/read_buildx_digest.py /tmp/gpu-metadata.json "${TARGET}")"
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           echo "reference=${IMAGE_NAME}@${digest}" >> "${GITHUB_OUTPUT}"
+      - name: Reclaim candidate verification space
+        run: |
+          docker buildx prune --all --force
+          docker system df
       - name: Verify candidate contents
         env:
           CANDIDATE: ${{ steps.candidate.outputs.reference }}

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -741,6 +741,12 @@ def test_gpu_publication_builds_only_explicit_main_variants() -> None:
     assert "if: github.ref == 'refs/heads/main'" in workflow
     assert "push-by-digest=true" in workflow
     assert 'BUILDX_NO_DEFAULT_ATTESTATIONS: "1"' in workflow
+    assert "docker buildx prune --all --force" in main_build
+    assert (
+        main_build.index("Build candidate by digest")
+        < main_build.index("docker buildx prune --all --force")
+        < main_build.index("Verify candidate contents")
+    )
     assert "--prefer-index=false" in workflow
     assert "application/vnd.docker.distribution.manifest.v2+json" in workflow
     assert "observed media type:" in workflow

--- a/packages/gateway/pyproject.toml
+++ b/packages/gateway/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Stanford University and the project authors" }]
 dependencies = [
-    "anthropic==0.117.1",
+    "anthropic==0.118.0",
     "filelock==3.29.7",
     "heartwood-adapters",
     "heartwood-core-adapter",

--- a/uv.lock
+++ b/uv.lock
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.117.1"
+version = "0.118.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -218,9 +218,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/97/7f03aa611b0005044e65290a9591f9fa73ac32d68499f52c322f836ba8ed/anthropic-0.117.1.tar.gz", hash = "sha256:e015a2d5b99fdf0aecac246e24ddb40d7bf93f9fe5b198771fab1559fb0101b9", size = 992232, upload-time = "2026-07-21T22:27:37.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/ff/bbad57650babf07ae9761f1d974fcee73430387b5d3aa0ddb395234906e8/anthropic-0.118.0.tar.gz", hash = "sha256:acb3c43b7e7592cf635fa21930e67a99d32641d68ccd53f625b52f71d7870d55", size = 994705, upload-time = "2026-07-22T16:43:57.019Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ea/36a068fa0b1761425cfdb16aeb799575e5846e6fdbdc7f73a10512f6e5a5/anthropic-0.117.1-py3-none-any.whl", hash = "sha256:7ab79e2c33c3dbde54c5800c4d535821e1c6d80bdf7de83ae1c0328bae563b76", size = 999820, upload-time = "2026-07-21T22:27:35.85Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/d46e77054d7efb61c85ef5e8c7e95927cc89988b6491b46d22af60d63bda/anthropic-0.118.0-py3-none-any.whl", hash = "sha256:524d835869b8e374510b3bcc552e28dbdafc035a61d63fc0088c4035286ef8fe", size = 1010922, upload-time = "2026-07-22T16:43:55.461Z" },
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = "==0.117.1" },
+    { name = "anthropic", specifier = "==0.118.0" },
     { name = "filelock", specifier = "==3.29.7" },
     { name = "heartwood-adapters", editable = "packages/adapters" },
     { name = "heartwood-core-adapter", editable = "packages/core-adapter" },


### PR DESCRIPTION
### :recycle: Current Situation and Problem

Terra GPU publication builds successfully but exhausts runner storage when the pushed image is pulled while BuildKit retains the complete build cache.

### :gear: Release Notes

- Prune the local BuildKit cache after pushing the immutable candidate and before registry verification.
- Guard the required ordering in the GPU publication contract tests.
- Update the Anthropic SDK to 0.118.0.

### :books: Documentation

No user-facing changes.

### :white_check_mark: Testing

- Complete Python suite and focused GPU publication compliance test
- Actionlint and yamllint
- Ruff formatting and lint

### Code of Conduct and Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
