### PR TITLE
Cache Architecture-Specific Container Validation

### DIFF
--- a/.github/workflows/capable-model.yml
+++ b/.github/workflows/capable-model.yml
@@ -26,15 +26,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build no-weight runtime image
-        run: >-
-          docker buildx bake --file docker-bake.hcl --load
-          --set runtime.platform=linux/amd64
-          --set runtime.tags=heartwood-capable:local
-          --set runtime.cache-from=type=gha,scope=runtime-amd64
-          --set runtime.cache-to=type=gha,scope=runtime-amd64,mode=max
-          --set runtime.attest=type=sbom,disabled=true
-          --set runtime.attest=type=provenance,disabled=true
-          runtime
+        uses: docker/bake-action@v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          files: docker-bake.hcl
+          load: true
+          provenance: false
+          sbom: false
+          source: .
+          targets: runtime
+          set: |
+            runtime.platform=linux/amd64
+            runtime.tags=heartwood-capable:local
+            runtime.cache-from=type=gha,scope=runtime-amd64
+            runtime.cache-to=type=gha,scope=runtime-amd64,mode=min
       - name: Prepare isolated model and project storage
         run: |
           sudo mkdir -p /tmp/heartwood-model-cache

--- a/.github/workflows/capable-model.yml
+++ b/.github/workflows/capable-model.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   acceptance:
     name: Capable Model OpenHands Acceptance (linux/amd64)
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Checkout repository

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -51,19 +51,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and stage image by digest
+        id: build
+        uses: docker/bake-action@v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          files: docker-bake.hcl
+          source: .
+          targets: runtime
+          set: |
+            runtime.platform=${{ matrix.platform }}
+            runtime.tags=${{ steps.image.outputs.name }}
+            runtime.cache-from=type=gha,scope=runtime-${{ matrix.suffix }}
+            runtime.cache-to=type=gha,scope=runtime-${{ matrix.suffix }},mode=min
+            runtime.output=type=image,push-by-digest=true,name-canonical=true,push=true
+      - name: Record staged image digest
         id: candidate
         env:
-          DOCKER_PLATFORM: ${{ matrix.platform }}
+          BUILD_METADATA: ${{ steps.build.outputs.metadata }}
           IMAGE_NAME: ${{ steps.image.outputs.name }}
         run: |
-          docker buildx bake --file docker-bake.hcl \
-            --set runtime.platform="${DOCKER_PLATFORM}" \
-            --set runtime.tags="${IMAGE_NAME}" \
-            --set "runtime.cache-from=type=gha,scope=runtime-${{ matrix.suffix }}" \
-            --set "runtime.cache-to=type=gha,scope=runtime-${{ matrix.suffix }},mode=max" \
-            --set "runtime.output=type=image,name=${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true" \
-            --metadata-file /tmp/metadata.json \
-            runtime
+          printf '%s\n' "${BUILD_METADATA}" > /tmp/metadata.json
           digest="$(python3 images/scripts/read_buildx_digest.py /tmp/metadata.json runtime)"
           mkdir -p /tmp/digests
           touch "/tmp/digests/${digest#sha256:}"
@@ -266,18 +274,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and stage Terra image by digest
-        id: candidate
+        id: build
+        uses: docker/bake-action@v7
         env:
           BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          files: docker-bake.hcl
+          source: .
+          targets: terra-runtime
+          set: |
+            terra-runtime.tags=${{ steps.image.outputs.name }}
+            terra-runtime.cache-from=type=gha,scope=terra-runtime-amd64
+            terra-runtime.cache-to=type=gha,scope=terra-runtime-amd64,mode=min
+            terra-runtime.output=type=image,push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=false
+      - name: Record staged Terra image digest
+        id: candidate
+        env:
+          BUILD_METADATA: ${{ steps.build.outputs.metadata }}
           IMAGE_NAME: ${{ steps.image.outputs.name }}
         run: |
-          docker buildx bake --file docker-bake.hcl \
-            --set terra-runtime.tags="${IMAGE_NAME}" \
-            --set terra-runtime.cache-from=type=gha,scope=terra-runtime-amd64 \
-            --set terra-runtime.cache-to=type=gha,scope=terra-runtime-amd64,mode=max \
-            --set "terra-runtime.output=type=image,name=${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=false" \
-            --metadata-file /tmp/terra-metadata.json \
-            terra-runtime
+          printf '%s\n' "${BUILD_METADATA}" > /tmp/terra-metadata.json
           digest="$(python3 images/scripts/read_buildx_digest.py /tmp/terra-metadata.json terra-runtime)"
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           echo "reference=${IMAGE_NAME}@${digest}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: blacksmith-16vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             suffix: amd64
           - platform: linux/arm64
-            runner: blacksmith-16vcpu-ubuntu-2404-arm
+            runner: ubuntu-24.04-arm
             suffix: arm64
     steps:
       - name: Checkout repository
@@ -256,7 +256,7 @@ jobs:
 
   build-terra:
     name: Stage, validate, and promote Terra image (linux/amd64)
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -29,8 +29,10 @@ jobs:
         include:
           - platform: linux/amd64
             runner: blacksmith-8vcpu-ubuntu-2404
+            cache_scope: runtime-amd64
           - platform: linux/arm64
             runner: blacksmith-8vcpu-ubuntu-2404-arm
+            cache_scope: runtime-arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -51,8 +53,19 @@ jobs:
           runtime runtime-gpu-nvidia
       - name: Build the no-weight image and run the isolated OpenHands stack
         env:
+          CACHE_SCOPE: ${{ matrix.cache_scope }}
           DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
-        run: docker compose -f images/generic/compose.yaml run --rm --build heartwood
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          docker buildx bake --file docker-bake.hcl --load \
+            --set "runtime.platform=${PLATFORM}" \
+            --set "runtime.tags=heartwood-runtime-smoke:local" \
+            --set "runtime.cache-from=type=gha,scope=${CACHE_SCOPE}" \
+            --set "runtime.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max" \
+            --set "runtime.attest=type=sbom,disabled=true" \
+            --set "runtime.attest=type=provenance,disabled=true" \
+            runtime
+          docker compose -f images/generic/compose.yaml run --rm --no-build heartwood
       - name: Verify named-volume persistence
         env:
           DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -51,21 +51,26 @@ jobs:
         run: >-
           docker buildx bake --file docker-bake.hcl --print
           runtime runtime-gpu-nvidia
-      - name: Build the no-weight image and run the isolated OpenHands stack
+      - name: Build the no-weight image
+        uses: docker/bake-action@v7
         env:
-          CACHE_SCOPE: ${{ matrix.cache_scope }}
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          files: docker-bake.hcl
+          load: true
+          provenance: false
+          sbom: false
+          source: .
+          targets: runtime
+          set: |
+            runtime.platform=${{ matrix.platform }}
+            runtime.tags=heartwood-runtime-smoke:local
+            runtime.cache-from=type=gha,scope=${{ matrix.cache_scope }}
+            runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=max
+      - name: Run the isolated OpenHands stack
+        env:
           DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
-          PLATFORM: ${{ matrix.platform }}
-        run: |
-          docker buildx bake --file docker-bake.hcl --load \
-            --set "runtime.platform=${PLATFORM}" \
-            --set "runtime.tags=heartwood-runtime-smoke:local" \
-            --set "runtime.cache-from=type=gha,scope=${CACHE_SCOPE}" \
-            --set "runtime.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max" \
-            --set "runtime.attest=type=sbom,disabled=true" \
-            --set "runtime.attest=type=provenance,disabled=true" \
-            runtime
-          docker compose -f images/generic/compose.yaml run --rm heartwood
+        run: docker compose -f images/generic/compose.yaml run --rm heartwood
       - name: Verify named-volume persistence
         env:
           DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -28,10 +28,10 @@ jobs:
       matrix:
         include:
           - platform: linux/amd64
-            runner: blacksmith-8vcpu-ubuntu-2404
+            runner: ubuntu-24.04
             cache_scope: runtime-amd64
           - platform: linux/arm64
-            runner: blacksmith-8vcpu-ubuntu-2404-arm
+            runner: ubuntu-24.04-arm
             cache_scope: runtime-arm64
     steps:
       - name: Checkout repository
@@ -99,7 +99,7 @@ jobs:
 
   terra-smoke:
     name: Terra image smoke test (linux/amd64)
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -66,7 +66,7 @@ jobs:
             runtime.platform=${{ matrix.platform }}
             runtime.tags=heartwood-runtime-smoke:local
             runtime.cache-from=type=gha,scope=${{ matrix.cache_scope }}
-            runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=max
+            runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=min
       - name: Run the isolated OpenHands stack
         env:
           DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/container-smoke.yml
+++ b/.github/workflows/container-smoke.yml
@@ -65,7 +65,7 @@ jobs:
             --set "runtime.attest=type=sbom,disabled=true" \
             --set "runtime.attest=type=provenance,disabled=true" \
             runtime
-          docker compose -f images/generic/compose.yaml run --rm --no-build heartwood
+          docker compose -f images/generic/compose.yaml run --rm heartwood
       - name: Verify named-volume persistence
         env:
           DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -77,8 +77,6 @@ jobs:
           set: |
             ${{ matrix.target }}.tags=${{ steps.image.outputs.name }}
             ${{ matrix.target }}.output=${{ matrix.media_output }}
-            ${{ matrix.target }}.cache-from=type=gha,scope=gpu-${{ matrix.target }}
-            ${{ matrix.target }}.cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min
       - name: Record candidate digest
         id: candidate
         env:

--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Build And Validate ${{ matrix.target }}
     needs: contract
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -39,10 +39,12 @@ jobs:
       matrix:
         include:
           - target: runtime-gpu-nvidia
+            runner: ubuntu-24.04
             commit_suffix: gpu-nvidia
             flatten: "false"
             media_output: type=image,push-by-digest=true,name-canonical=true,push=true
           - target: terra-runtime-gpu-nvidia
+            runner: blacksmith-16vcpu-ubuntu-2404
             commit_suffix: terra-gpu-nvidia
             flatten: "true"
             media_output: type=image,push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=false

--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     name: Build And Validate ${{ matrix.target }}
     needs: contract
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -63,20 +63,28 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build candidate by digest
-        id: candidate
+        id: build
+        uses: docker/bake-action@v7
         env:
           BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          files: docker-bake.hcl
+          source: .
+          targets: ${{ matrix.target }}
+          set: |
+            ${{ matrix.target }}.tags=${{ steps.image.outputs.name }}
+            ${{ matrix.target }}.output=${{ matrix.media_output }}
+            ${{ matrix.target }}.cache-from=type=gha,scope=gpu-${{ matrix.target }}
+            ${{ matrix.target }}.cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min
+      - name: Record candidate digest
+        id: candidate
+        env:
+          BUILD_METADATA: ${{ steps.build.outputs.metadata }}
           IMAGE_NAME: ${{ steps.image.outputs.name }}
           TARGET: ${{ matrix.target }}
-          MEDIA_OUTPUT: ${{ matrix.media_output }}
         run: |
-          docker buildx bake --file docker-bake.hcl \
-            --set "${TARGET}.tags=${IMAGE_NAME}" \
-            --set "${TARGET}.output=${MEDIA_OUTPUT},name=${IMAGE_NAME}" \
-            --set "${TARGET}.cache-from=type=gha,scope=gpu-${TARGET}" \
-            --set "${TARGET}.cache-to=type=gha,scope=gpu-${TARGET},mode=max" \
-            --metadata-file /tmp/gpu-metadata.json \
-            "${TARGET}"
+          printf '%s\n' "${BUILD_METADATA}" > /tmp/gpu-metadata.json
           digest="$(python3 images/scripts/read_buildx_digest.py /tmp/gpu-metadata.json "${TARGET}")"
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
           echo "reference=${IMAGE_NAME}@${digest}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/gpu-container-pr.yml
+++ b/.github/workflows/gpu-container-pr.yml
@@ -44,14 +44,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build and validate candidate without image export
+        uses: docker/bake-action@v7
         env:
-          TARGET: ${{ matrix.target }}
-        run: |
-          docker buildx bake --progress=plain --file docker-bake.hcl \
-            --set "${TARGET}.target=gpu-ci-validate" \
-            --set "${TARGET}.output=type=cacheonly" \
-            --set "${TARGET}.cache-from=type=gha,scope=gpu-${TARGET}" \
-            --set "${TARGET}.cache-to=type=gha,scope=gpu-${TARGET},mode=max" \
-            --set "${TARGET}.attest=type=sbom,disabled=true" \
-            --set "${TARGET}.attest=type=provenance,disabled=true" \
-            "${TARGET}"
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          files: docker-bake.hcl
+          provenance: false
+          sbom: false
+          source: .
+          targets: ${{ matrix.target }}
+          set: |
+            ${{ matrix.target }}.target=gpu-ci-validate
+            ${{ matrix.target }}.output=type=cacheonly
+            ${{ matrix.target }}.cache-from=type=gha,scope=gpu-${{ matrix.target }}
+            ${{ matrix.target }}.cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min

--- a/.github/workflows/gpu-container-pr.yml
+++ b/.github/workflows/gpu-container-pr.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     name: Build GPU candidate ${{ matrix.target }}
     needs: contract
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/gpu-container-pr.yml
+++ b/.github/workflows/gpu-container-pr.yml
@@ -60,5 +60,3 @@ jobs:
           set: |
             ${{ matrix.target }}.target=gpu-ci-validate
             ${{ matrix.target }}.output=type=cacheonly
-            ${{ matrix.target }}.cache-from=type=gha,scope=gpu-${{ matrix.target }}
-            ${{ matrix.target }}.cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min

--- a/.github/workflows/gpu-container-pr.yml
+++ b/.github/workflows/gpu-container-pr.yml
@@ -31,11 +31,15 @@ jobs:
   build:
     name: Build GPU candidate ${{ matrix.target }}
     needs: contract
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        target: [runtime-gpu-nvidia, terra-runtime-gpu-nvidia]
+        include:
+          - target: runtime-gpu-nvidia
+            runner: ubuntu-24.04
+          - target: terra-runtime-gpu-nvidia
+            runner: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   package:
     name: Build And Verify Native Assets
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   quality:
     name: Lint, type-check, and test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   web-ui:
     name: TypeScript, Unit, And Browser Checks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,10 +33,8 @@ group "default" {
 }
 
 target "runtime-gpu-nvidia" {
-  inherits = ["runtime"]
+  inherits = ["_runtime_common"]
   platforms = ["linux/amd64"]
-  cache-from = ["type=gha,scope=runtime-gpu-nvidia"]
-  cache-to = ["type=gha,scope=runtime-gpu-nvidia,mode=min"]
   args = {
     HEARTWOOD_IMAGE_FLAVOR = "runtime-gpu-nvidia"
     HEARTWOOD_GPU_RUNTIME = "vllm"
@@ -47,18 +45,24 @@ target "runtime-gpu-nvidia" {
   ]
 }
 
-target "runtime" {
+target "_runtime_common" {
   context = "."
   dockerfile = "images/Dockerfile"
   target = "runtime-image"
-  platforms = ["linux/amd64", "linux/arm64"]
   pull = true
-  cache-from = ["type=gha"]
-  cache-to = ["type=gha,mode=min"]
   attest = ["type=sbom", "type=provenance,mode=max"]
   args = {
-    HEARTWOOD_IMAGE_FLAVOR = "runtime"
     HEARTWOOD_VERSION = "${HEARTWOOD_VERSION}"
+  }
+}
+
+target "runtime" {
+  inherits = ["_runtime_common"]
+  platforms = ["linux/amd64", "linux/arm64"]
+  cache-from = ["type=gha"]
+  cache-to = ["type=gha,mode=min"]
+  args = {
+    HEARTWOOD_IMAGE_FLAVOR = "runtime"
   }
   tags = [
     "${IMAGE_NAME}:${IMAGE_CHANNEL}",
@@ -103,8 +107,6 @@ target "terra-runtime" {
 
 target "terra-runtime-gpu-nvidia" {
   inherits = ["_terra_common"]
-  cache-from = ["type=gha,scope=terra-runtime-gpu-nvidia"]
-  cache-to = ["type=gha,scope=terra-runtime-gpu-nvidia,mode=min"]
   output = ["type=registry,oci-mediatypes=false"]
   args = {
     HEARTWOOD_IMAGE_FLAVOR = "terra-runtime-gpu-nvidia"

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -784,7 +784,7 @@ def test_gpu_publication_builds_only_explicit_main_variants() -> None:
     assert ".output=type=cacheonly" in pull_request_workflow
     assert "output=type=docker" not in pull_request_workflow
     assert "docker/setup-buildx-action@v4" in pull_request_workflow
-    assert "blacksmith-16vcpu-ubuntu-2404" in pull_request_workflow
+    assert "blacksmith-8vcpu-ubuntu-2404" in pull_request_workflow
     assert "uses: docker/bake-action@v7" in pull_request_workflow
     assert "cache-from=type=gha,scope=gpu-${{ matrix.target }}" in pull_request_workflow
     assert "cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min" in pull_request_workflow
@@ -1072,8 +1072,8 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
     assert '--reference "${CANDIDATE_DIGEST}"' in publish
     assert publish.count("^sha256:[0-9a-f]{64}$") == 2
     assert "if: github.ref == 'refs/heads/main'" not in publish
-    assert "blacksmith-16vcpu-ubuntu-2404" in publish
-    assert "blacksmith-16vcpu-ubuntu-2404-arm" in publish
+    assert "runner: ubuntu-24.04" in publish
+    assert "runner: ubuntu-24.04-arm" in publish
     assert "cache-from=type=gha" in publish
     assert "cache-to=type=gha" in publish
     assert publish.count("uses: docker/bake-action@v7") == 2

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -191,7 +191,8 @@ def test_container_smoke_uses_bake_as_the_heartwood_build_contract() -> None:
     capable_workflow = _read(".github/workflows/capable-model.yml")
 
     assert workflow.count("docker buildx bake --file docker-bake.hcl --call=check") == 2
-    assert "--set runtime.tags=heartwood-capable:local" in capable_workflow
+    assert "runtime.tags=heartwood-capable:local" in capable_workflow
+    assert "uses: docker/bake-action@v7" in capable_workflow
     assert "--build-arg HEARTWOOD_" not in workflow
     assert "--file images/Dockerfile" not in workflow
 
@@ -774,23 +775,27 @@ def test_gpu_publication_builds_only_explicit_main_variants() -> None:
     assert "runtime-gpu-nvidia" in workflow
     assert "terra-runtime-gpu-nvidia" in workflow
     assert "Build GPU candidate ${{ matrix.target }}" in pull_request_workflow
-    assert 'target=gpu-ci-validate"' in pull_request_workflow
+    assert ".target=gpu-ci-validate" in pull_request_workflow
     contract_action = _read(".github/actions/validate-gpu-contract/action.yml")
     assert workflow.count("uses: ./.github/actions/validate-gpu-contract") == 1
     assert pull_request_workflow.count("uses: ./.github/actions/validate-gpu-contract") == 1
     assert "bash -n images/gpu/install_runtime.sh" in contract_action
     assert "test -x images/gpu/install_runtime.sh" in contract_action
-    assert 'output=type=cacheonly"' in pull_request_workflow
+    assert ".output=type=cacheonly" in pull_request_workflow
     assert "output=type=docker" not in pull_request_workflow
     assert "docker/setup-buildx-action@v4" in pull_request_workflow
     assert "blacksmith-16vcpu-ubuntu-2404" in pull_request_workflow
-    assert "cache-from=type=gha,scope=gpu-${TARGET}" in pull_request_workflow
-    assert "cache-to=type=gha,scope=gpu-${TARGET},mode=max" in pull_request_workflow
+    assert "uses: docker/bake-action@v7" in pull_request_workflow
+    assert "cache-from=type=gha,scope=gpu-${{ matrix.target }}" in pull_request_workflow
+    assert "cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min" in pull_request_workflow
+    assert "uses: docker/bake-action@v7" in workflow
+    assert "mode=max" not in pull_request_workflow
+    assert "mode=max" not in main_build
     assert "deploy/reclaim-github-runner-space.sh" not in pull_request_workflow
     assert "/usr/local/lib/android" in runner_cleanup
     assert "/usr/share/dotnet" in runner_cleanup
-    assert "attest=type=sbom,disabled=true" in pull_request_workflow
-    assert "attest=type=provenance,disabled=true" in pull_request_workflow
+    assert "sbom: false" in pull_request_workflow
+    assert "provenance: false" in pull_request_workflow
     assert "Promote GPU Channel Tags" in workflow
     assert "workflow_dispatch:" not in workflow
     assert "qualification_configuration:" in qualification
@@ -1071,6 +1076,8 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
     assert "blacksmith-16vcpu-ubuntu-2404-arm" in publish
     assert "cache-from=type=gha" in publish
     assert "cache-to=type=gha" in publish
+    assert publish.count("uses: docker/bake-action@v7") == 2
+    assert "mode=max" not in publish
     assert "immutable generic commit tag already exists with a different manifest" in publish
     assert "newly created generic commit tag does not match validated candidate manifest" in publish
     assert "immutable Terra commit tag already exists with a different digest" in publish

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -253,6 +253,7 @@ def test_bake_file_has_portable_and_explicit_nvidia_variants() -> None:
     bake = _read("docker-bake.hcl")
 
     assert _target_names(bake) == {
+        "_runtime_common",
         "runtime",
         "runtime-gpu-nvidia",
         "_terra_common",
@@ -266,8 +267,9 @@ def test_bake_file_has_portable_and_explicit_nvidia_variants() -> None:
     assert '"${IMAGE_NAME}:${IMAGE_CHANNEL}-gpu-nvidia"' in bake
     assert '"${IMAGE_NAME}:${IMAGE_CHANNEL}-terra-gpu-nvidia"' in bake
     assert bake.count('HEARTWOOD_GPU_RUNTIME = "vllm"') == 2
-    assert "type=gha,scope=runtime-gpu-nvidia,mode=min" in bake
-    assert "type=gha,scope=terra-runtime-gpu-nvidia,mode=min" in bake
+    assert 'inherits = ["_runtime_common"]' in bake
+    assert "type=gha,scope=runtime-gpu-nvidia" not in bake
+    assert "type=gha,scope=terra-runtime-gpu-nvidia" not in bake
     assert 'output = ["type=registry,oci-mediatypes=false"]' in bake
     assert "HEARTWOOD_BUNDLE_LOCAL_MODEL" not in bake
     assert "coder-7b" not in bake
@@ -787,11 +789,13 @@ def test_gpu_publication_builds_only_explicit_main_variants() -> None:
     assert "runner: ubuntu-24.04" in pull_request_workflow
     assert "runner: blacksmith-16vcpu-ubuntu-2404" in pull_request_workflow
     assert "uses: docker/bake-action@v7" in pull_request_workflow
-    assert "cache-from=type=gha,scope=gpu-${{ matrix.target }}" in pull_request_workflow
-    assert "cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min" in pull_request_workflow
+    assert "cache-from=type=gha" not in pull_request_workflow
+    assert "cache-to=type=gha" not in pull_request_workflow
     assert "uses: docker/bake-action@v7" in workflow
     assert "mode=max" not in pull_request_workflow
     assert "mode=max" not in main_build
+    assert "cache-from=type=gha" not in main_build
+    assert "cache-to=type=gha" not in main_build
     assert "deploy/reclaim-github-runner-space.sh" not in pull_request_workflow
     assert "/usr/local/lib/android" in runner_cleanup
     assert "/usr/share/dotnet" in runner_cleanup

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -784,7 +784,8 @@ def test_gpu_publication_builds_only_explicit_main_variants() -> None:
     assert ".output=type=cacheonly" in pull_request_workflow
     assert "output=type=docker" not in pull_request_workflow
     assert "docker/setup-buildx-action@v4" in pull_request_workflow
-    assert "blacksmith-8vcpu-ubuntu-2404" in pull_request_workflow
+    assert "runner: ubuntu-24.04" in pull_request_workflow
+    assert "runner: blacksmith-16vcpu-ubuntu-2404" in pull_request_workflow
     assert "uses: docker/bake-action@v7" in pull_request_workflow
     assert "cache-from=type=gha,scope=gpu-${{ matrix.target }}" in pull_request_workflow
     assert "cache-to=type=gha,scope=gpu-${{ matrix.target }},mode=min" in pull_request_workflow

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -1124,7 +1124,7 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
     assert "Generic OpenHands smoke" in smoke
     assert "platform: linux/amd64" in smoke
     assert "platform: linux/arm64" in smoke
-    assert "runner: blacksmith-8vcpu-ubuntu-2404-arm" in smoke
+    assert "runner: ubuntu-24.04-arm" in smoke
     assert "runtime runtime-gpu-nvidia" in smoke
     assert "terra-runtime terra-runtime-gpu-nvidia terra-ci" in smoke
     assert "edge-terra-ci" in smoke

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -276,21 +276,36 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "    if: ${{ always() }}" in pull_request
     assert "\n    if:" not in smoke
     assert "\n    if:" not in gpu
-    assert "blacksmith-8vcpu-ubuntu-2404" in smoke
-    assert "blacksmith-8vcpu-ubuntu-2404-arm" in smoke
+    assert "runner: ubuntu-24.04" in smoke
+    assert "runner: ubuntu-24.04-arm" in smoke
     assert "cache_scope: runtime-amd64" in smoke
     assert "cache_scope: runtime-arm64" in smoke
     assert "uses: docker/bake-action@v7" in smoke
     assert "runtime.cache-from=type=gha,scope=${{ matrix.cache_scope }}" in smoke
     assert "runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=min" in smoke
     assert "docker compose -f images/generic/compose.yaml run --rm heartwood" in smoke
-    assert "blacksmith-16vcpu-ubuntu-2404" in gpu
-    assert "blacksmith-16vcpu-ubuntu-2404" in capable
+    assert "blacksmith-8vcpu-ubuntu-2404" in gpu
+    assert "blacksmith" not in capable
     assert "uses: docker/bake-action@v7" in capable
     assert "uses: docker/bake-action@v7" in gpu
     assert "cache-from=type=gha" in gpu
     assert "cache-to=type=gha" in gpu
     assert dependabot.count('multi-ecosystem-group: "weekly-dependencies"') == 3
+
+
+def test_blacksmith_runners_are_reserved_for_gpu_image_builds() -> None:
+    workflow_root = Path(".github/workflows")
+    blacksmith_workflows = {
+        path.name
+        for path in workflow_root.glob("*.yml")
+        if "blacksmith-" in path.read_text(encoding="utf-8")
+    }
+
+    assert blacksmith_workflows == {"gpu-container-image.yml", "gpu-container-pr.yml"}
+    for workflow_name in blacksmith_workflows:
+        workflow = (workflow_root / workflow_name).read_text(encoding="utf-8")
+        assert "blacksmith-8vcpu-ubuntu-2404" in workflow
+        assert "blacksmith-16vcpu" not in workflow
 
 
 def test_release_gate_is_fail_fast_and_uses_readiness_check() -> None:

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -280,8 +280,9 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "blacksmith-8vcpu-ubuntu-2404-arm" in smoke
     assert "cache_scope: runtime-amd64" in smoke
     assert "cache_scope: runtime-arm64" in smoke
-    assert "runtime.cache-from=type=gha,scope=${CACHE_SCOPE}" in smoke
-    assert "runtime.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max" in smoke
+    assert "uses: docker/bake-action@v7" in smoke
+    assert "runtime.cache-from=type=gha,scope=${{ matrix.cache_scope }}" in smoke
+    assert "runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=max" in smoke
     assert "docker compose -f images/generic/compose.yaml run --rm heartwood" in smoke
     assert "blacksmith-16vcpu-ubuntu-2404" in gpu
     assert "blacksmith-16vcpu-ubuntu-2404" in capable

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -278,6 +278,11 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "\n    if:" not in gpu
     assert "blacksmith-8vcpu-ubuntu-2404" in smoke
     assert "blacksmith-8vcpu-ubuntu-2404-arm" in smoke
+    assert "cache_scope: runtime-amd64" in smoke
+    assert "cache_scope: runtime-arm64" in smoke
+    assert 'runtime.cache-from=type=gha,scope=${CACHE_SCOPE}' in smoke
+    assert 'runtime.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max' in smoke
+    assert "docker compose -f images/generic/compose.yaml run --rm --no-build" in smoke
     assert "blacksmith-16vcpu-ubuntu-2404" in gpu
     assert "blacksmith-16vcpu-ubuntu-2404" in capable
     assert "cache-from=type=gha" in gpu

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -289,8 +289,8 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "blacksmith" not in capable
     assert "uses: docker/bake-action@v7" in capable
     assert "uses: docker/bake-action@v7" in gpu
-    assert "cache-from=type=gha" in gpu
-    assert "cache-to=type=gha" in gpu
+    assert "cache-from=type=gha" not in gpu
+    assert "cache-to=type=gha" not in gpu
     assert dependabot.count('multi-ecosystem-group: "weekly-dependencies"') == 3
 
 

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -282,7 +282,7 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "cache_scope: runtime-arm64" in smoke
     assert "uses: docker/bake-action@v7" in smoke
     assert "runtime.cache-from=type=gha,scope=${{ matrix.cache_scope }}" in smoke
-    assert "runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=max" in smoke
+    assert "runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=min" in smoke
     assert "docker compose -f images/generic/compose.yaml run --rm heartwood" in smoke
     assert "blacksmith-16vcpu-ubuntu-2404" in gpu
     assert "blacksmith-16vcpu-ubuntu-2404" in capable

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -284,7 +284,8 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "runtime.cache-from=type=gha,scope=${{ matrix.cache_scope }}" in smoke
     assert "runtime.cache-to=type=gha,scope=${{ matrix.cache_scope }},mode=min" in smoke
     assert "docker compose -f images/generic/compose.yaml run --rm heartwood" in smoke
-    assert "blacksmith-8vcpu-ubuntu-2404" in gpu
+    assert "runner: ubuntu-24.04" in gpu
+    assert "runner: blacksmith-16vcpu-ubuntu-2404" in gpu
     assert "blacksmith" not in capable
     assert "uses: docker/bake-action@v7" in capable
     assert "uses: docker/bake-action@v7" in gpu
@@ -293,7 +294,7 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert dependabot.count('multi-ecosystem-group: "weekly-dependencies"') == 3
 
 
-def test_blacksmith_runners_are_reserved_for_gpu_image_builds() -> None:
+def test_blacksmith_runners_are_reserved_for_terra_gpu_image_builds() -> None:
     workflow_root = Path(".github/workflows")
     blacksmith_workflows = {
         path.name
@@ -304,8 +305,12 @@ def test_blacksmith_runners_are_reserved_for_gpu_image_builds() -> None:
     assert blacksmith_workflows == {"gpu-container-image.yml", "gpu-container-pr.yml"}
     for workflow_name in blacksmith_workflows:
         workflow = (workflow_root / workflow_name).read_text(encoding="utf-8")
-        assert "blacksmith-8vcpu-ubuntu-2404" in workflow
-        assert "blacksmith-16vcpu" not in workflow
+        assert workflow.count("blacksmith-16vcpu-ubuntu-2404") == 1
+        assert "target: runtime-gpu-nvidia\n            runner: ubuntu-24.04" in workflow
+        assert (
+            "target: terra-runtime-gpu-nvidia\n"
+            "            runner: blacksmith-16vcpu-ubuntu-2404"
+        ) in workflow
 
 
 def test_release_gate_is_fail_fast_and_uses_readiness_check() -> None:

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -308,8 +308,7 @@ def test_blacksmith_runners_are_reserved_for_terra_gpu_image_builds() -> None:
         assert workflow.count("blacksmith-16vcpu-ubuntu-2404") == 1
         assert "target: runtime-gpu-nvidia\n            runner: ubuntu-24.04" in workflow
         assert (
-            "target: terra-runtime-gpu-nvidia\n"
-            "            runner: blacksmith-16vcpu-ubuntu-2404"
+            "target: terra-runtime-gpu-nvidia\n            runner: blacksmith-16vcpu-ubuntu-2404"
         ) in workflow
 
 

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -280,9 +280,9 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "blacksmith-8vcpu-ubuntu-2404-arm" in smoke
     assert "cache_scope: runtime-amd64" in smoke
     assert "cache_scope: runtime-arm64" in smoke
-    assert 'runtime.cache-from=type=gha,scope=${CACHE_SCOPE}' in smoke
-    assert 'runtime.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max' in smoke
-    assert "docker compose -f images/generic/compose.yaml run --rm --no-build" in smoke
+    assert "runtime.cache-from=type=gha,scope=${CACHE_SCOPE}" in smoke
+    assert "runtime.cache-to=type=gha,scope=${CACHE_SCOPE},mode=max" in smoke
+    assert "docker compose -f images/generic/compose.yaml run --rm heartwood" in smoke
     assert "blacksmith-16vcpu-ubuntu-2404" in gpu
     assert "blacksmith-16vcpu-ubuntu-2404" in capable
     assert "cache-from=type=gha" in gpu

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -286,6 +286,8 @@ def test_pull_request_validation_has_no_optional_job_placeholders() -> None:
     assert "docker compose -f images/generic/compose.yaml run --rm heartwood" in smoke
     assert "blacksmith-16vcpu-ubuntu-2404" in gpu
     assert "blacksmith-16vcpu-ubuntu-2404" in capable
+    assert "uses: docker/bake-action@v7" in capable
+    assert "uses: docker/bake-action@v7" in gpu
     assert "cache-from=type=gha" in gpu
     assert "cache-to=type=gha" in gpu
     assert dependabot.count('multi-ecosystem-group: "weekly-dependencies"') == 3


### PR DESCRIPTION
### :recycle: Current situation & Problem

Container workflows declared GitHub Actions caches through raw Bake commands, which did not receive the cache runtime credentials. Broad accelerated-runner use also consumed quota without consistently shortening the critical path.

### :gear: Release Notes

- Run cache-bearing builds through the official Docker Bake action.
- Isolate AMD64, ARM64, and Terra cache scopes with bounded exports.
- Avoid remote caching for large GPU runtime layers where transfer overhead exceeds rebuild time.
- Reserve Blacksmith 16-vCPU runners for Terra GPU image builds only; use GitHub-hosted runners elsewhere.
- Preserve digest-based image verification and promotion.

### :books: Documentation

No user-facing changes.

### :white_check_mark: Testing

- Workflow and container governance tests
- actionlint, yamllint, Ruff, and whitespace validation
- AMD64, ARM64, Terra, and GPU container checks

### Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).