### PR TITLE
Prepare 0.2.0 Beta 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker run --rm -it \
   --env HOME=/tmp \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
   heartwood --interface web --host 0.0.0.0
 ```
 

--- a/VERSION.toml
+++ b/VERSION.toml
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 # SPDX-License-Identifier: MIT
 
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "GIT_SHA" {
 }
 
 variable "HEARTWOOD_VERSION" {
-  default = "0.2.0-beta.8"
+  default = "0.2.0-beta.9"
 }
 
 variable "TERRA_BASE_IMAGE" {

--- a/documentation/contribute/releases.md
+++ b/documentation/contribute/releases.md
@@ -23,7 +23,7 @@ The workflow verifies immutable container candidates, builds and tests native as
 ## Stable and Preview Documentation
 
 A stable version updates the `stable` alias and the documentation root.
-A prerelease such as `0.2.0-beta.8` updates the `preview` alias without replacing the stable root.
+A prerelease such as `0.2.0-beta.9` updates the `preview` alias without replacing the stable root.
 
 The version store is deployed to GitHub Pages and retains immutable version paths.
 Publishing the same version with different content is rejected.

--- a/documentation/models/offline.md
+++ b/documentation/models/offline.md
@@ -32,7 +32,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
   heartwood
 ```
 

--- a/documentation/platforms/carina.md
+++ b/documentation/platforms/carina.md
@@ -41,7 +41,7 @@ Do not use a shared project root itself as the Heartwood project.
 ```bash
 cd heartwood-installation
 curl --fail --location --remote-name \
-  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.8/heartwood-installer
+  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.9/heartwood-installer
 chmod 700 heartwood-installer
 ./heartwood-installer --platform carina
 export PATH="$PWD/bin:$PATH"

--- a/documentation/platforms/containers.md
+++ b/documentation/platforms/containers.md
@@ -27,7 +27,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
   heartwood
 ```
 
@@ -44,7 +44,7 @@ docker run --rm -it \
   --env HOME=/tmp \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
   heartwood --interface web --host 0.0.0.0
 ```
 
@@ -63,7 +63,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8-gpu-nvidia \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-gpu-nvidia \
   heartwood
 ```
 
@@ -75,10 +75,10 @@ Review the [GPU compatibility matrix](../reference/gpu-compatibility.md) before 
 
 Use immutable release tags for research work:
 
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8` — standard AMD64/ARM64 image;
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8-gpu-nvidia` — NVIDIA GPU image;
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8-terra` — Terra CPU image; and
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8-terra-gpu-nvidia` — Terra NVIDIA image.
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9` — standard AMD64/ARM64 image;
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-gpu-nvidia` — NVIDIA GPU image;
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra` — Terra CPU image; and
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra-gpu-nvidia` — Terra NVIDIA image.
 
 The moving `edge` tags represent current `main` and are intended for development, not reproducible analyses.
 Release publication verifies candidate digests and manifest shape before creating version tags.

--- a/documentation/platforms/native-linux.md
+++ b/documentation/platforms/native-linux.md
@@ -48,7 +48,7 @@ mkdir -m 700 heartwood-installation
 cd heartwood-installation
 
 curl --fail --location --remote-name \
-  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.8/heartwood-installer
+  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.9/heartwood-installer
 chmod 700 heartwood-installer
 ./heartwood-installer --platform generic
 export PATH="$PWD/bin:$PATH"

--- a/documentation/platforms/terra.md
+++ b/documentation/platforms/terra.md
@@ -41,8 +41,8 @@ Use one of these combinations:
 
 | Model Route | Image | Practical Starting Point |
 |---|---|---|
-| Research environment or hosted service | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8-terra` | 8 CPUs, 30 GB RAM, 50 GB persistent disk |
-| Qualified managed GPU inference | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.8-terra-gpu-nvidia` | 32 CPUs, 120 GB RAM, two T4 GPUs with 16 GB each, 200 GB persistent disk |
+| Research environment or hosted service | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra` | 8 CPUs, 30 GB RAM, 50 GB persistent disk |
+| Qualified managed GPU inference | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra-gpu-nvidia` | 32 CPUs, 120 GB RAM, two T4 GPUs with 16 GB each, 200 GB persistent disk |
 
 A hosted model is the shortest first run.
 Use the GPU image for a capable model managed inside the Terra environment.

--- a/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
+++ b/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.8"
+  heartwood.version: "0.2.0-beta.9"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
+++ b/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.8",
+  "heartwood.version": "0.2.0-beta.9",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/packages/adapters/pyproject.toml
+++ b/packages/adapters/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-adapters"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Adapter service provider interfaces and conformance checks for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/adapters/src/heartwood/adapters/__init__.py
+++ b/packages/adapters/src/heartwood/adapters/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "assert_registry_adapter_conforms",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/adapters/src/heartwood/adapters/conformance.py
+++ b/packages/adapters/src/heartwood/adapters/conformance.py
@@ -64,7 +64,7 @@ def assert_data_source_adapter_conforms(
 def assert_registry_adapter_conforms(
     adapter: RegistryAdapter,
     skill_id: str = "heartwood.synthetic.omop-cohort-summary",
-    version: str = "0.2.0-beta.8",
+    version: str = "0.2.0-beta.9",
 ) -> None:
     """Assert the shared minimum contract for registry adapters."""
     assert adapter.registry_id

--- a/packages/adapters/tests/test_conformance.py
+++ b/packages/adapters/tests/test_conformance.py
@@ -119,7 +119,7 @@ class FakeRegistryAdapter:
     def verify_skill(self, reference: SkillReference) -> RegistryVerification:
         """Verify the synthetic skill reference."""
         return RegistryVerification(
-            verified=reference.version == "0.2.0-beta.8",
+            verified=reference.version == "0.2.0-beta.9",
             reason="synthetic fixture registry result",
         )
 

--- a/packages/audit/pyproject.toml
+++ b/packages/audit/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-audit"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Hash-chained audit logging for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/audit/src/heartwood/audit/__init__.py
+++ b/packages/audit/src/heartwood/audit/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "scrub_json_value",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-cli"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "The heartwood command-line interface — the primary interaction surface."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/cli/src/heartwood/cli/__init__.py
+++ b/packages/cli/src/heartwood/cli/__init__.py
@@ -72,7 +72,7 @@ from heartwood.session import (
 
 __all__ = ["__version__", "main"]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"
 
 _PROG = "heartwood"
 

--- a/packages/compliance/pyproject.toml
+++ b/packages/compliance/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-compliance"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Synthetic-only reviewer packet and audit bundle generation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/compliance/src/heartwood/compliance/__init__.py
+++ b/packages/compliance/src/heartwood/compliance/__init__.py
@@ -12,4 +12,4 @@ from heartwood.compliance._reviewer_packet import ReviewerPacket, ReviewerPacket
 
 __all__ = ["ReviewerPacket", "ReviewerPacketGenerator", "__version__"]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -219,7 +219,7 @@ def test_runtime_image_sets_the_release_version_label() -> None:
     assert "ARG HEARTWOOD_VERSION=development" in dockerfile
     assert 'org.opencontainers.image.version="${HEARTWOOD_VERSION}"' in dockerfile
     assert 'variable "HEARTWOOD_VERSION"' in bake
-    assert 'default = "0.2.0-beta.8"' in bake
+    assert 'default = "0.2.0-beta.9"' in bake
     assert bake.count('HEARTWOOD_VERSION = "${HEARTWOOD_VERSION}"') == 2
 
 

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -189,9 +189,9 @@ def test_prerelease_sources_use_semver_and_python_lock_uses_pep440(
 
     assert _release_verifier().source_version_errors(tmp_path, version) == []
 
-    skill_metadata.write_text('{"heartwood.version": "0.2.0-beta.8"}\n', encoding="utf-8")
+    skill_metadata.write_text('{"heartwood.version": "0.2.0-beta.9"}\n', encoding="utf-8")
     assert (
-        "skills/verified/example/metadata.json: 0.2.0-beta.8"
+        "skills/verified/example/metadata.json: 0.2.0-beta.9"
         in _release_verifier().source_version_errors(tmp_path, version)
     )
 

--- a/packages/core-adapter/pyproject.toml
+++ b/packages/core-adapter/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-core-adapter"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Core harness orchestration for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/core-adapter/src/heartwood/core_adapter/__init__.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/detector/pyproject.toml
+++ b/packages/detector/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-detector"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Deterministic, propose-not-commit environment and dataset detection for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/detector/src/heartwood/detector/__init__.py
+++ b/packages/detector/src/heartwood/detector/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "platform_detection_evidence",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/fixtures/pyproject.toml
+++ b/packages/fixtures/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-fixtures"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Synthetic fixture linting for Heartwood tests and replay artifacts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/fixtures/src/heartwood/fixtures/__init__.py
+++ b/packages/fixtures/src/heartwood/fixtures/__init__.py
@@ -12,4 +12,4 @@ from heartwood.fixtures.lint import FixtureFinding, lint_fixture_tree, main
 
 __all__ = ["FixtureFinding", "__version__", "lint_fixture_tree", "main"]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/gateway/pyproject.toml
+++ b/packages/gateway/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-gateway"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Session gateway for Heartwood command and event streams."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/pyproject.toml
+++ b/packages/model-policy/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-model-policy"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Deny-by-default model-call policy evaluation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/src/heartwood/model_policy/__init__.py
+++ b/packages/model-policy/src/heartwood/model_policy/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "normalize_endpoint",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/notebook/pyproject.toml
+++ b/packages/notebook/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-notebook"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Notebook-facing Python API and widget bridge for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/notebook/src/heartwood/notebook/__init__.py
+++ b/packages/notebook/src/heartwood/notebook/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "render_widgets",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/schemas/pyproject.toml
+++ b/packages/schemas/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-schemas"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Versioned typed schemas for Heartwood policy, audit, detection, and skill metadata records."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/schemas/src/heartwood/schemas/__init__.py
+++ b/packages/schemas/src/heartwood/schemas/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "schema_names",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/schemas/tests/test_schema_records.py
+++ b/packages/schemas/tests/test_schema_records.py
@@ -159,14 +159,14 @@ def test_skill_metadata_accepts_skill_md_aliases() -> None:
             "heartwood.phi-risk": "none",
             "heartwood.trust-tier": "verified",
             "heartwood.requires-network": "false",
-            "heartwood.version": "0.2.0-beta.8",
+            "heartwood.version": "0.2.0-beta.9",
             "heartwood.sig": "sigstore:synthetic-bundle",
         }
     )
     assert metadata.dataset_types == ("omop-cdm", "fhir")
     assert metadata.platforms == ("generic", "terra")
     assert metadata.requires_network is False
-    assert metadata.version == "0.2.0-beta.8"
+    assert metadata.version == "0.2.0-beta.9"
 
 
 @pytest.mark.parametrize(

--- a/packages/session/pyproject.toml
+++ b/packages/session/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-session"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Shared session command/event contract for Heartwood interfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/session/src/heartwood/session/__init__.py
+++ b/packages/session/src/heartwood/session/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "validate_session_id",
 ]
 
-__version__ = "0.2.0-beta.8"
+__version__ = "0.2.0-beta.9"

--- a/packages/skills/pyproject.toml
+++ b/packages/skills/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-skills"
-version = "0.2.0-beta.8"
+version = "0.2.0-beta.9"
 description = "Local SKILL.md verification and deterministic skill test harnesses for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/webui/package-lock.json
+++ b/packages/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0-beta.8",
+  "version": "0.2.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heartwood/webui",
-      "version": "0.2.0-beta.8",
+      "version": "0.2.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@stanfordspezi/spezi-web-design-system": "0.20.0",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0-beta.8",
+  "version": "0.2.0-beta.9",
   "private": true,
   "type": "module",
   "description": "Researcher web UI for Heartwood sessions.",

--- a/skills/verified/aggregate-export/SKILL.md
+++ b/skills/verified/aggregate-export/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.8"
+  heartwood.version: "0.2.0-beta.9"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/aggregate-export/metadata.json
+++ b/skills/verified/aggregate-export/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.8",
+  "heartwood.version": "0.2.0-beta.9",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/baseline-model/SKILL.md
+++ b/skills/verified/baseline-model/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.8"
+  heartwood.version: "0.2.0-beta.9"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/baseline-model/metadata.json
+++ b/skills/verified/baseline-model/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.8",
+  "heartwood.version": "0.2.0-beta.9",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/omop-cohort-summary/SKILL.md
+++ b/skills/verified/omop-cohort-summary/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.8"
+  heartwood.version: "0.2.0-beta.9"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/omop-cohort-summary/metadata.json
+++ b/skills/verified/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.8",
+  "heartwood.version": "0.2.0-beta.9",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1472,7 +1472,7 @@ wheels = [
 
 [[package]]
 name = "heartwood-adapters"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/adapters" }
 dependencies = [
     { name = "heartwood-detector" },
@@ -1489,7 +1489,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-audit"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/audit" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1500,7 +1500,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-cli"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/cli" }
 dependencies = [
     { name = "heartwood-gateway" },
@@ -1521,7 +1521,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-compliance"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/compliance" }
 dependencies = [
     { name = "heartwood-audit" },
@@ -1536,7 +1536,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-core-adapter"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/core-adapter" }
 dependencies = [
     { name = "heartwood-adapters" },
@@ -1557,7 +1557,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-detector"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/detector" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1568,12 +1568,12 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-fixtures"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/fixtures" }
 
 [[package]]
 name = "heartwood-gateway"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/gateway" }
 dependencies = [
     { name = "anthropic" },
@@ -1612,7 +1612,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-model-policy"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/model-policy" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1623,7 +1623,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-notebook"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/notebook" }
 dependencies = [
     { name = "heartwood-gateway" },
@@ -1647,7 +1647,7 @@ provides-extras = ["widgets"]
 
 [[package]]
 name = "heartwood-schemas"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/schemas" }
 dependencies = [
     { name = "pydantic" },
@@ -1658,7 +1658,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-session"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/session" }
 dependencies = [
     { name = "pydantic" },
@@ -1669,7 +1669,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-skills"
-version = "0.2.0b8"
+version = "0.2.0b9"
 source = { editable = "packages/skills" }
 dependencies = [
     { name = "heartwood-schemas" },


### PR DESCRIPTION
### :recycle: Current Situation & Problem

The merged dependency and CI updates need a synchronized prerelease version before publication.

### :gear: Release Notes

- Prepare Heartwood 0.2.0 Beta 9.
- Synchronize package, container, skill, lockfile, and documentation versions.

### :books: Documentation

Installation and container examples now reference Beta 9.

### :white_check_mark: Testing

- Release source verification
- 86 release-governance, documentation, and container tests
- Web production build
- Lock and diff validation

### Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).