### PR TITLE
Strengthen Beta Release Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker run --rm -it \
   --env HOME=/tmp \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
   heartwood --interface web --host 0.0.0.0
 ```
 

--- a/VERSION.toml
+++ b/VERSION.toml
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 # SPDX-License-Identifier: MIT
 
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -478,7 +478,8 @@ fi
 replace_symlink "${current_target}" "${root}/current"
 installation_succeeded="true"
 
+cleanup
+trap - EXIT
 stage "Installation complete"
-rm -rf "${installer_state}"
 printf 'Installed %s in %d seconds.\n' "${release_version}" "${SECONDS}"
 printf 'Add %s to PATH, then run: heartwood doctor\n' "${root}/bin"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "GIT_SHA" {
 }
 
 variable "HEARTWOOD_VERSION" {
-  default = "0.2.0-beta.9"
+  default = "0.2.0-beta.10"
 }
 
 variable "TERRA_BASE_IMAGE" {

--- a/documentation/architecture/testing.md
+++ b/documentation/architecture/testing.md
@@ -28,7 +28,7 @@ Qualification profiles select external model weights and runtime arguments again
 An optional protected self-hosted GPU job runs the same model qualification used on managed platforms when an eligible runner is configured.
 Without GPU hardware, CI does not claim successful CUDA initialization or GPU model loading.
 
-The shared coding-agent acceptance test performs direct model inference and then drives the real Heartwood gateway and OpenHands adapter through a structured terminal proposal, grouped approval, synthetic file modification, independent file verification, fresh-process replay, and hash-chain-verified audit export.
+The shared coding-agent acceptance test performs direct model inference and then drives the real Heartwood gateway and OpenHands adapter through structured terminal proposals, grouped approval and rejection, synthetic file modification, byte-exact independent verification, proof that the rejected action did not execute, fresh-process replay, and hash-chain-verified audit export.
 It emits a machine-readable qualification record containing the exact runtime, model revision, GPU, driver, context, tensor parallelism, server parser, and agent tool mode.
 The CPU capable-model job and GPU qualification wrapper use this same acceptance contract instead of maintaining separate agent scenarios.
 

--- a/documentation/contribute/releases.md
+++ b/documentation/contribute/releases.md
@@ -23,7 +23,7 @@ The workflow verifies immutable container candidates, builds and tests native as
 ## Stable and Preview Documentation
 
 A stable version updates the `stable` alias and the documentation root.
-A prerelease such as `0.2.0-beta.9` updates the `preview` alias without replacing the stable root.
+A prerelease such as `0.2.0-beta.10` updates the `preview` alias without replacing the stable root.
 
 The version store is deployed to GitHub Pages and retains immutable version paths.
 Publishing the same version with different content is rejected.

--- a/documentation/models/offline.md
+++ b/documentation/models/offline.md
@@ -32,7 +32,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
   heartwood
 ```
 

--- a/documentation/models/run-with-heartwood.md
+++ b/documentation/models/run-with-heartwood.md
@@ -8,6 +8,7 @@ SPDX-License-Identifier: MIT
 
 Heartwood images and the generic Linux package include managed inference software but no model weights.
 After a supported model is selected and downloaded or imported, the normal `heartwood` command verifies the files, plans context against available memory, starts the runtime, waits for readiness, and then opens the requested interface.
+Downloading and verification are separate costs: a cached model avoids network transfer but Heartwood still verifies its immutable source and file hashes before use.
 
 ## Download and Start
 
@@ -62,6 +63,8 @@ heartwood runtime start --task-profile powerful --partition dev --time 01:00:00
 On Carina, Heartwood prints the complete Slurm request and asks before allocating a GPU.
 On provisioned Terra compute, it uses the attached resources without submitting a scheduler request.
 Model download and scheduler allocation require separate confirmation.
+An advanced `runtime start --dry-run` may show a compatible recommendation when the project has no selected model, but it never persists that recommendation.
+Complete the normal `heartwood` setup flow before starting or allocating the runtime.
 
 ## Stop the Runtime
 

--- a/documentation/platforms/carina.md
+++ b/documentation/platforms/carina.md
@@ -41,7 +41,7 @@ Do not use a shared project root itself as the Heartwood project.
 ```bash
 cd heartwood-installation
 curl --fail --location --remote-name \
-  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.9/heartwood-installer
+  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.10/heartwood-installer
 chmod 700 heartwood-installer
 ./heartwood-installer --platform carina
 export PATH="$PWD/bin:$PATH"
@@ -81,6 +81,8 @@ Those current Stanford terms, not Heartwood platform detection, determine data e
 
 Choose **Run with Heartwood**, select a catalog model or another public Hugging Face repository, and review the download and resource plan.
 Model files are stored under the project's `.heartwood/models/`, not the installation directory.
+Model setup verifies every file before it persists the selection.
+On project storage, verification of a large existing cache can take several minutes even when no network download is needed.
 
 When you start Heartwood with a selected Heartwood-managed model, it inspects the GPU-capable Slurm partitions, available L40S count, GPU memory, CPU and RAM limits, existing model cache, and requested capability tier.
 It then prints the strongest compatible qualified model, expected download and startup range, and complete `srun` request.
@@ -121,11 +123,16 @@ Preview a particular capability tier without downloading or allocating:
 heartwood runtime start --task-profile powerful --dry-run
 ```
 
+This preview is a recommendation only.
+It does not select or download the model.
+Run `heartwood` and complete model setup before using `heartwood runtime start` without `--dry-run`; Heartwood otherwise stops before requesting an allocation.
+
 `auto` prefers **Powerful** on Carina and falls back to the strongest qualified configuration that fits one available allocation.
 Use `--task-profile standard`, `powerful`, or `maximum` when the task has a known resource envelope.
 The `--gpus` option is an advanced constraint and must match a catalog configuration that was qualified at that tensor-parallel size.
 
 Heartwood scopes model caches to the project, waits up to ten minutes by default, and reports the current stage and elapsed startup time every 15 seconds.
+The installer reports completion only after temporary installation state and locks have been removed.
 For scripted deployment, `--yes-download` and `--yes-request-allocation` are separate explicit approvals; normal interactive use should retain both prompts.
 
 ## Review, Exit, and Return

--- a/documentation/platforms/containers.md
+++ b/documentation/platforms/containers.md
@@ -27,7 +27,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
   heartwood
 ```
 
@@ -44,7 +44,7 @@ docker run --rm -it \
   --env HOME=/tmp \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
   heartwood --interface web --host 0.0.0.0
 ```
 
@@ -63,7 +63,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-gpu-nvidia \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-gpu-nvidia \
   heartwood
 ```
 
@@ -75,10 +75,10 @@ Review the [GPU compatibility matrix](../reference/gpu-compatibility.md) before 
 
 Use immutable release tags for research work:
 
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9` — standard AMD64/ARM64 image;
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-gpu-nvidia` — NVIDIA GPU image;
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra` — Terra CPU image; and
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra-gpu-nvidia` — Terra NVIDIA image.
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10` — standard AMD64/ARM64 image;
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-gpu-nvidia` — NVIDIA GPU image;
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra` — Terra CPU image; and
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra-gpu-nvidia` — Terra NVIDIA image.
 
 The moving `edge` tags represent current `main` and are intended for development, not reproducible analyses.
 Release publication verifies candidate digests and manifest shape before creating version tags.

--- a/documentation/platforms/native-linux.md
+++ b/documentation/platforms/native-linux.md
@@ -48,7 +48,7 @@ mkdir -m 700 heartwood-installation
 cd heartwood-installation
 
 curl --fail --location --remote-name \
-  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.9/heartwood-installer
+  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.10/heartwood-installer
 chmod 700 heartwood-installer
 ./heartwood-installer --platform generic
 export PATH="$PWD/bin:$PATH"

--- a/documentation/platforms/terra.md
+++ b/documentation/platforms/terra.md
@@ -31,9 +31,10 @@ Open the workspace's Jupyter Cloud Environment settings and configure the enviro
 
 1. Select **Customize**, then choose **Custom Environment** under application configuration.
 2. Select the CPU and memory combination from the table below.
-3. Enter the corresponding container image.
-4. Enable the GPU, when required, and verify the GPU type and count.
-5. Set auto-pause and review every value before selecting **Create**.
+3. Enable the GPU, when required, and verify the GPU type and count.
+4. Set the persistent-disk size and auto-pause interval.
+5. Enter the corresponding container image last.
+6. Review every value before selecting **Create**.
 
 Terra can reset the image or GPU selection when the CPU choice changes, so set compute resources first and verify the complete form before creation.
 
@@ -41,8 +42,8 @@ Use one of these combinations:
 
 | Model Route | Image | Practical Starting Point |
 |---|---|---|
-| Research environment or hosted service | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra` | 8 CPUs, 30 GB RAM, 50 GB persistent disk |
-| Qualified managed GPU inference | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.9-terra-gpu-nvidia` | 32 CPUs, 120 GB RAM, two T4 GPUs with 16 GB each, 200 GB persistent disk |
+| Research environment or hosted service | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra` | 8 CPUs, 30 GB RAM, 50 GB persistent disk |
+| Qualified managed GPU inference | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra-gpu-nvidia` | 32 CPUs, 120 GB RAM, two T4 GPUs with 16 GB each, 200 GB persistent disk |
 
 A hosted model is the shortest first run.
 Use the GPU image for a capable model managed inside the Terra environment.
@@ -63,6 +64,10 @@ Larger GPU memory can enable context capacities above 32K when the model support
 See [Choose a Heartwood-Managed Model](../models/choose-managed.md) for download and resource estimates and [GPU Compatibility](../reference/gpu-compatibility.md) for exact runtime combinations.
 
 Retain the persistent disk when replacing compute and copy valuable results to workspace storage.
+Before downloading a managed model, open a terminal and run `df -h /home/jupyter`.
+The disk needs the model's recommended free space in addition to existing notebooks, project files, and `.heartwood/` state.
+If the retained disk is too small, preserve important files, delete only the Cloud Environment, and recreate it with a larger persistent disk.
+For an existing project that already contains model files or other analyses, 250 GB is a safer managed-inference starting point than the 200 GB fresh-project minimum.
 See [Starting and Customizing Your Jupyter App](https://support.terra.bio/hc/en-us/articles/5075814468379-Starting-and-customizing-your-Jupyter-app).
 
 ## Create and Verify the Environment
@@ -173,6 +178,7 @@ Deleting the persistent disk removes `.heartwood/` and project files stored only
 - If a Heartwood browser URL returns **401** or **404**, use the terminal or notebook interface; browser access is not supported on Terra.
 - If `import heartwood` fails in a notebook, switch the notebook kernel to **Python 3 (Heartwood)** and restart the kernel.
 - If a model download stops, rerun Heartwood from the same project; verified files in `.heartwood/models/` are reused.
+- If Heartwood reports insufficient persistent storage, run `df -h /home/jupyter`, retain needed files, and recreate only the Cloud Environment with a larger disk.
 - If model startup is slow or fails, compare the printed model plan with attached RAM, GPU memory, and persistent-disk space, then inspect `.heartwood/logs/local-model.log` from the same project.
 - If Heartwood reports an unsupported P4, P100, or V100, delete and recreate the Cloud Environment with a T4 while retaining the persistent disk; do not replace the released vLLM or PyTorch packages in place.
 - If the GPU is not detected, confirm that the GPU image and GPU were selected together, then run `nvidia-smi` and `heartwood doctor` from the project terminal.

--- a/documentation/reference/gpu-compatibility.md
+++ b/documentation/reference/gpu-compatibility.md
@@ -75,9 +75,10 @@ The acceptance test must establish all of the following:
 2. OpenHands uses the catalog-qualified tool mode: native structured tools for supported parsers or its prompt-conversion path for models that do not reliably emit native calls;
 3. Heartwood presents the complete action set for approval;
 4. approval executes the proposed operation and modifies only the synthetic project;
-5. an independent check verifies the exact file result;
-6. a fresh process replays the session; and
-7. audit export validates event coverage, hash-chain integrity, and content scrubbing.
+5. a second proposed action set is rejected and does not modify the project;
+6. an independent check verifies the exact file bytes;
+7. a fresh process replays both decisions and the approved result; and
+8. audit export validates event coverage, hash-chain integrity, and content scrubbing.
 
 The result records the GPU model, count, memory, driver, runtime versions, model revision, context size, tensor parallelism, server parser, and agent tool mode.
 Not-tested configurations are not added to the managed catalog.

--- a/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
+++ b/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.9"
+  heartwood.version: "0.2.0-beta.10"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
+++ b/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.9",
+  "heartwood.version": "0.2.0-beta.10",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/images/generic/scripts/coding_agent_e2e.sh
+++ b/images/generic/scripts/coding_agent_e2e.sh
@@ -47,6 +47,8 @@ runtime_port="${HEARTWOOD_LOCAL_RUNTIME_PORT:-8765}"
 cohort_path="${project}/cohort-summary.json"
 exact_path="${project}/heartwood-exact-output.txt"
 rejected_path="${project}/heartwood-rejected-output.txt"
+exact_name="$(basename -- "${exact_path}")"
+rejected_name="$(basename -- "${rejected_path}")"
 events_path="${workspace}/${session_id}/events.jsonl"
 audit_path="${state_root}/audit-export.jsonl"
 
@@ -141,7 +143,7 @@ run_heartwood models connect heartwood heartwood-managed-runtime | tee -a "${tra
 run_heartwood models validate heartwood | tee -a "${transcript}"
 run_heartwood actions set ask-every-time | tee -a "${transcript}"
 run_heartwood --session-id "${session_id}" \
-  --prompt "Call the terminal tool to execute this exact command: ${heartwood_python} ${runtime_root}/skills/verified/omop-cohort-summary/scripts/run.py --data-root input --target-condition-concept-id 201826 --minimum-age 18 --aggregate-count-floor 20 --output cohort-summary.json && printf 'heartwood-agent-exact-ok\\n' > heartwood-exact-output.txt && cat cohort-summary.json. Do not describe the command as text and do not call another tool after it completes. Wait for the terminal result, then report the aggregate cohort result." \
+  --prompt "Call the terminal tool to execute this exact command: ${heartwood_python} ${runtime_root}/skills/verified/omop-cohort-summary/scripts/run.py --data-root input --target-condition-concept-id 201826 --minimum-age 18 --aggregate-count-floor 20 --output cohort-summary.json && printf 'heartwood-agent-exact-ok\\n' > ${exact_name} && cat cohort-summary.json. Do not describe the command as text and do not call another tool after it completes. Wait for the terminal result, then report the aggregate cohort result." \
   | tee -a "${transcript}"
 
 for _ in 1 2 3 4; do
@@ -153,7 +155,7 @@ for _ in 1 2 3 4; do
 done
 
 run_heartwood --session-id "${session_id}" \
-  --prompt "Call the terminal tool once to execute exactly: printf 'this-action-must-remain-rejected\\n' > heartwood-rejected-output.txt. Do not call another tool." \
+  --prompt "Call the terminal tool once to execute exactly: printf 'this-action-must-remain-rejected\\n' > ${rejected_name}. Do not call another tool." \
   | tee -a "${transcript}"
 
 pending_id="$(pending_action_id)"

--- a/images/generic/scripts/coding_agent_e2e.sh
+++ b/images/generic/scripts/coding_agent_e2e.sh
@@ -45,6 +45,8 @@ inference="${project}/qualification-inference.json"
 command_timeout="${HEARTWOOD_COMMAND_TIMEOUT:-900}"
 runtime_port="${HEARTWOOD_LOCAL_RUNTIME_PORT:-8765}"
 cohort_path="${project}/cohort-summary.json"
+exact_path="${project}/heartwood-exact-output.txt"
+rejected_path="${project}/heartwood-rejected-output.txt"
 events_path="${workspace}/${session_id}/events.jsonl"
 audit_path="${state_root}/audit-export.jsonl"
 
@@ -67,7 +69,13 @@ export OPENHANDS_SUPPRESS_BANNER=1
 
 rm -rf "${project}/input" "${state_root}"
 mkdir -p "${project}/input"
-rm -f "${cohort_path}" "${transcript}" "${replay}" "${report}"
+rm -f \
+  "${cohort_path}" \
+  "${exact_path}" \
+  "${rejected_path}" \
+  "${transcript}" \
+  "${replay}" \
+  "${report}"
 cp "${runtime_root}/fixtures/synthetic/omop-like/"*.csv "${project}/input/"
 cd "${project}"
 
@@ -106,16 +114,8 @@ run_heartwood() {
   timeout "${command_timeout}" "${heartwood_cli}" "$@"
 }
 
-run_heartwood models refresh heartwood | tee -a "${transcript}"
-run_heartwood models connect heartwood heartwood-managed-runtime | tee -a "${transcript}"
-run_heartwood models validate heartwood | tee -a "${transcript}"
-run_heartwood actions set ask-every-time | tee -a "${transcript}"
-run_heartwood --session-id "${session_id}" \
-  --prompt "Call the terminal tool to execute this exact command: ${heartwood_python} ${runtime_root}/skills/verified/omop-cohort-summary/scripts/run.py --data-root input --target-condition-concept-id 201826 --minimum-age 18 --aggregate-count-floor 20 --output cohort-summary.json && cat cohort-summary.json. Do not describe the command as text and do not call another tool after it completes. Wait for the terminal result, then report the aggregate cohort result." \
-  | tee -a "${transcript}"
-
-for _ in 1 2 3 4; do
-  pending_id="$("${heartwood_python}" - "${events_path}" <<'PY'
+pending_action_id() {
+  "${heartwood_python}" - "${events_path}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -134,12 +134,34 @@ pending = [
 ]
 print(pending[-1] if pending else "")
 PY
-)"
+}
+
+run_heartwood models refresh heartwood | tee -a "${transcript}"
+run_heartwood models connect heartwood heartwood-managed-runtime | tee -a "${transcript}"
+run_heartwood models validate heartwood | tee -a "${transcript}"
+run_heartwood actions set ask-every-time | tee -a "${transcript}"
+run_heartwood --session-id "${session_id}" \
+  --prompt "Call the terminal tool to execute this exact command: ${heartwood_python} ${runtime_root}/skills/verified/omop-cohort-summary/scripts/run.py --data-root input --target-condition-concept-id 201826 --minimum-age 18 --aggregate-count-floor 20 --output cohort-summary.json && printf 'heartwood-agent-exact-ok\\n' > heartwood-exact-output.txt && cat cohort-summary.json. Do not describe the command as text and do not call another tool after it completes. Wait for the terminal result, then report the aggregate cohort result." \
+  | tee -a "${transcript}"
+
+for _ in 1 2 3 4; do
+  pending_id="$(pending_action_id)"
   if [[ -z "${pending_id}" ]]; then
     break
   fi
   run_heartwood --session-id "${session_id}" allow | tee -a "${transcript}"
 done
+
+run_heartwood --session-id "${session_id}" \
+  --prompt "Call the terminal tool once to execute exactly: printf 'this-action-must-remain-rejected\\n' > heartwood-rejected-output.txt. Do not call another tool." \
+  | tee -a "${transcript}"
+
+pending_id="$(pending_action_id)"
+if [[ -z "${pending_id}" ]]; then
+  echo "coding-agent rejection check did not produce a pending action" >&2
+  exit 1
+fi
+run_heartwood --session-id "${session_id}" reject | tee -a "${transcript}"
 
 run_heartwood --session-id "${session_id}" replay | tee "${replay}"
 run_heartwood --session-id "${session_id}" audit export \

--- a/images/generic/scripts/verify_coding_agent_e2e.py
+++ b/images/generic/scripts/verify_coding_agent_e2e.py
@@ -78,8 +78,11 @@ def verify_run(
         for event in events
         if event.kind == "confirmation.resolved"
     }
-    if decisions != {"approved"}:
-        raise ValueError(f"coding-agent actions were not approved: {sorted(decisions)}")
+    if decisions != {"approved", "denied"}:
+        raise ValueError(
+            "coding-agent qualification must record one approved and one denied action set: "
+            f"{sorted(decisions)}"
+        )
 
     tool_executions = [event for event in events if event.kind == "tool.execution.recorded"]
     terminal_executions = [
@@ -140,14 +143,26 @@ def verify_run(
         raise ValueError("coding-agent artifact contains row-level output")
     if cohort["export_guard"].get("exportable") is not True:
         raise ValueError("coding-agent artifact unexpectedly failed its count floor")
+    if not artifact_path.read_bytes().endswith(b"\n"):
+        raise ValueError("coding-agent artifact does not end with a newline")
+    exact_path = artifact_path.with_name("heartwood-exact-output.txt")
+    if not exact_path.is_file() or exact_path.read_bytes() != b"heartwood-agent-exact-ok\n":
+        raise ValueError("coding-agent exact-content artifact is incorrect")
+    rejected_path = artifact_path.with_name("heartwood-rejected-output.txt")
+    if rejected_path.exists():
+        raise ValueError("coding-agent rejected action modified the project")
 
     inference = json.loads(inference_path.read_text(encoding="utf-8"))
     if inference.get("content_nonempty") is not True:
         raise ValueError("direct model inference did not return content")
 
     replay = replay_path.read_text(encoding="utf-8")
-    if "Tool terminal exit=0" not in replay or "Action set approved" not in replay:
-        raise ValueError("fresh-process replay is missing the approved tool execution")
+    if (
+        "Tool terminal exit=0" not in replay
+        or "Action set approved" not in replay
+        or "Action set denied" not in replay
+    ):
+        raise ValueError("fresh-process replay is missing the approved or denied action set")
 
     audit = AuditLog(audit_path)
     audit_events = audit.read()
@@ -161,6 +176,8 @@ def verify_run(
         str(artifact_path.resolve().parent),
         "target-condition-concept-id",
         "Call the terminal tool",
+        "heartwood-agent-exact-ok",
+        "this-action-must-remain-rejected",
     ):
         if sensitive_value in audit_text:
             raise ValueError("audit export contains unsanitized task content")
@@ -173,7 +190,9 @@ def verify_run(
             "model_loaded_and_inferred": True,
             "tool_call_proposed": True,
             "grouped_approval_recorded": True,
+            "grouped_rejection_recorded": True,
             "file_modified_and_verified": True,
+            "exact_content_verified": True,
             "fresh_process_replay_verified": True,
             "audit_export_verified": True,
         },

--- a/packages/adapters/pyproject.toml
+++ b/packages/adapters/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-adapters"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Adapter service provider interfaces and conformance checks for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/adapters/src/heartwood/adapters/__init__.py
+++ b/packages/adapters/src/heartwood/adapters/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "assert_registry_adapter_conforms",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/adapters/src/heartwood/adapters/conformance.py
+++ b/packages/adapters/src/heartwood/adapters/conformance.py
@@ -64,7 +64,7 @@ def assert_data_source_adapter_conforms(
 def assert_registry_adapter_conforms(
     adapter: RegistryAdapter,
     skill_id: str = "heartwood.synthetic.omop-cohort-summary",
-    version: str = "0.2.0-beta.9",
+    version: str = "0.2.0-beta.10",
 ) -> None:
     """Assert the shared minimum contract for registry adapters."""
     assert adapter.registry_id

--- a/packages/adapters/tests/test_conformance.py
+++ b/packages/adapters/tests/test_conformance.py
@@ -119,7 +119,7 @@ class FakeRegistryAdapter:
     def verify_skill(self, reference: SkillReference) -> RegistryVerification:
         """Verify the synthetic skill reference."""
         return RegistryVerification(
-            verified=reference.version == "0.2.0-beta.9",
+            verified=reference.version == "0.2.0-beta.10",
             reason="synthetic fixture registry result",
         )
 

--- a/packages/audit/pyproject.toml
+++ b/packages/audit/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-audit"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Hash-chained audit logging for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/audit/src/heartwood/audit/__init__.py
+++ b/packages/audit/src/heartwood/audit/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "scrub_json_value",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-cli"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "The heartwood command-line interface — the primary interaction surface."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/cli/src/heartwood/cli/__init__.py
+++ b/packages/cli/src/heartwood/cli/__init__.py
@@ -72,7 +72,7 @@ from heartwood.session import (
 
 __all__ = ["__version__", "main"]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"
 
 _PROG = "heartwood"
 
@@ -99,9 +99,12 @@ _MODEL_SOURCE_ARGUMENTS = {
     "stanford-ai-api-gateway": "stanford-ai-api-gateway",
 }
 _MODEL_DOWNLOAD_ACTIVITY = InteractionActivity(
-    label="Downloading and verifying the model",
-    waiting_label="Still downloading and verifying the model",
-    guidance="Large models can take several minutes. Keep this process running.",
+    label="Preparing and verifying the model",
+    waiting_label="Still preparing and verifying the model",
+    guidance=(
+        "Large downloads and full verification of existing model files can take several minutes. "
+        "Keep this process running."
+    ),
 )
 _STARTUP_ACTIVITY = InteractionActivity(
     label="Checking the project and environment",

--- a/packages/cli/src/heartwood/cli/_launch.py
+++ b/packages/cli/src/heartwood/cli/_launch.py
@@ -119,6 +119,7 @@ class LaunchPlan:
     startup_seconds_max: int | None = None
     environment_notes: tuple[str, ...] = ()
     download_required: bool = False
+    model_selected: bool = True
 
     def format(self) -> str:
         """Render the launch proposal without secrets."""
@@ -132,6 +133,11 @@ class LaunchPlan:
             (
                 "Catalog model: "
                 f"{self.artifact_id if self.artifact_id is not None else 'not selected'}"
+            ),
+            (
+                "Model status: selected for this project"
+                if self.model_selected
+                else "Model status: recommendation only; complete setup before startup"
             ),
             f"Runtime: {self.runtime if self.runtime is not None else 'not selected'}",
             (
@@ -341,6 +347,7 @@ def build_launch_plan(options: LaunchOptions, env: Mapping[str, str]) -> LaunchP
     """Build a platform-specific launch plan without changing external state."""
     platform_id = select_platform_adapter(env).adapter_id
     selection = _local_model_selection(options.project, env)
+    model_selected = selection is not None
     if selection is None:
         recommendation = _recommend_model(options, env, platform_id=platform_id)
         if recommendation is not None:
@@ -404,6 +411,7 @@ def build_launch_plan(options: LaunchOptions, env: Mapping[str, str]) -> LaunchP
             and selection.catalog_source == "catalog"
             and not selection.model_root.exists()
         ),
+        model_selected=model_selected,
     )
 
 
@@ -441,6 +449,13 @@ def run_launch(
             print(
                 "\nNo qualified Heartwood-managed model matches the detected resources. "
                 "Run `heartwood models managed` for lower-resource and advanced options."
+            )
+            return 64
+        if not plan.model_selected:
+            print(
+                "\nThis plan is a resource recommendation, not a selected model. "
+                "Run `heartwood` to choose Run with Heartwood, or use `heartwood setup` "
+                "before requesting a download or GPU allocation."
             )
             return 64
         if plan.download_required:

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -1327,7 +1327,7 @@ def test_cli_plans_and_downloads_hugging_face_identifier_without_runtime_flags(
     assert "Heartwood model plan" in output
     assert "Runtime: CPU" in output
     assert "Recommended: 8 CPU cores" in output
-    assert "Downloading and verifying the model" in captured.err
+    assert "Preparing and verifying the model" in captured.err
     assert "Model files are ready:" in output
     assert "Run `heartwood` to continue setup or open Heartwood." in output
     assert calls == [

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -18,6 +18,7 @@ import pytest
 
 from heartwood.adapters.platform import GenericPlatformAdapter
 from heartwood.cli import (
+    _MODEL_DOWNLOAD_ACTIVITY,
     __version__,
     _consume_prompt,
     _float_payload,
@@ -133,6 +134,15 @@ def test_version_is_available(capsys: pytest.CaptureFixture[str]) -> None:
 
     assert error.value.code == 0
     assert f"heartwood {__version__}" in capsys.readouterr().out
+
+
+def test_model_preparation_progress_explains_long_running_work() -> None:
+    assert _MODEL_DOWNLOAD_ACTIVITY.label == "Preparing and verifying the model"
+    assert _MODEL_DOWNLOAD_ACTIVITY.waiting_label == "Still preparing and verifying the model"
+    assert _MODEL_DOWNLOAD_ACTIVITY.guidance == (
+        "Large downloads and full verification of existing model files can take several minutes. "
+        "Keep this process running."
+    )
 
 
 def test_line_mode_reports_elapsed_progress_for_a_slow_turn(

--- a/packages/cli/tests/test_launch.py
+++ b/packages/cli/tests/test_launch.py
@@ -22,6 +22,7 @@ from heartwood.adapters.platform import select_platform_adapter
 from heartwood.cli._launch import (
     LaunchConfigurationError,
     LaunchOptions,
+    LaunchPlan,
     LocalRuntimeSelection,
     _allocation_resources,
     _available_gpu_memory_bytes,
@@ -458,6 +459,44 @@ def test_launch_reports_missing_selection_artifact_and_runtime(
     )
     assert run_launch(_options(tmp_path), env=env) == 69
     assert "vLLM executable is unavailable" in capsys.readouterr().out
+
+
+def test_recommended_model_cannot_download_or_allocate_before_setup(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    options = _options(tmp_path, selected=False, yes_download=True, yes_request_allocation=True)
+    runner_called = False
+
+    def runner(_command: Sequence[str]) -> int:
+        nonlocal runner_called
+        runner_called = True
+        return 0
+
+    plan = LaunchPlan(
+        platform_id="carina",
+        allocation_required=True,
+        allocation_command=("srun", "--pty", "heartwood"),
+        model_root=options.project.models_dir / "recommended-model",
+        state_root=options.project.state_root,
+        project_root=options.project.root,
+        runtime="vllm",
+        model_id="heartwood-managed-model",
+        artifact_id="recommended-model",
+        context_window=32_768,
+        download_required=True,
+        model_selected=False,
+    )
+    monkeypatch.setattr("heartwood.cli._launch.build_launch_plan", lambda *_args: plan)
+
+    assert run_launch(options, env={"HEARTWOOD_PLATFORM": "carina"}, run_fn=runner) == 64
+    output = capsys.readouterr().out
+    assert "Model status: recommendation only" in output
+    assert "Run `heartwood` to choose Run with Heartwood" in output
+    assert not runner_called
+    assert plan.model_root is not None
+    assert not plan.model_root.exists()
 
 
 def test_launch_rejects_short_context_before_starting_runtime(

--- a/packages/cli/tests/test_launch.py
+++ b/packages/cli/tests/test_launch.py
@@ -499,6 +499,47 @@ def test_recommended_model_cannot_download_or_allocate_before_setup(
     assert not plan.model_root.exists()
 
 
+def test_real_launch_plan_cannot_download_a_recommendation_before_setup(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "heartwood.gateway._gpu_environment.discover_visible_gpus",
+        lambda _env: tuple(
+            GpuDevice(
+                index=index,
+                name="Tesla T4",
+                total_memory_bytes=16 * 1024**3,
+                free_memory_bytes=15 * 1024**3,
+                driver_version="570.86.15",
+                compute_capability=(7, 5),
+            )
+            for index in range(2)
+        ),
+    )
+    options = _options(
+        tmp_path,
+        selected=False,
+        gpus=None,
+        yes_download=True,
+        yes_request_allocation=True,
+    )
+    runner_called = False
+
+    def runner(_command: Sequence[str]) -> int:
+        nonlocal runner_called
+        runner_called = True
+        return 0
+
+    assert run_launch(options, env={"HEARTWOOD_PLATFORM": "terra"}, run_fn=runner) == 64
+    output = capsys.readouterr().out
+    assert "Model status: recommendation only" in output
+    assert "Run `heartwood` to choose Run with Heartwood" in output
+    assert not runner_called
+    assert not any(options.project.models_dir.iterdir())
+
+
 def test_launch_rejects_short_context_before_starting_runtime(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/packages/compliance/pyproject.toml
+++ b/packages/compliance/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-compliance"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Synthetic-only reviewer packet and audit bundle generation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/compliance/src/heartwood/compliance/__init__.py
+++ b/packages/compliance/src/heartwood/compliance/__init__.py
@@ -12,4 +12,4 @@ from heartwood.compliance._reviewer_packet import ReviewerPacket, ReviewerPacket
 
 __all__ = ["ReviewerPacket", "ReviewerPacketGenerator", "__version__"]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/compliance/tests/test_coding_agent_qualification.py
+++ b/packages/compliance/tests/test_coding_agent_qualification.py
@@ -82,7 +82,30 @@ def _acceptance_files(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
             "tool.execution.recorded",
             {"tool_name": "finish", "exit_code": 0},
         ),
-        _event(6, "audit.export.recorded", {"scrubbed": True}),
+        _event(
+            6,
+            "model_call.decision.recorded",
+            {
+                "decision": {"decision": "allow"},
+                "model_profile": {"action_confirmation_mode": "always-confirm"},
+            },
+        ),
+        _event(
+            7,
+            "tool_call.proposed",
+            {"tool_call_id": "tool-2", "tool_name": "terminal"},
+        ),
+        _event(
+            8,
+            "confirmation.requested",
+            {"request": {"tool_call_id": "tool-2"}},
+        ),
+        _event(
+            9,
+            "confirmation.resolved",
+            {"tool_call_id": "tool-2", "decision": "denied"},
+        ),
+        _event(10, "audit.export.recorded", {"scrubbed": True}),
     )
     events_path = tmp_path / "events.jsonl"
     events_path.write_text(
@@ -111,12 +134,14 @@ def _acceptance_files(tmp_path: Path) -> tuple[Path, Path, Path, Path, Path]:
                 "quality_checks": {"aggregate_only_output": True},
                 "export_guard": {"exportable": True},
             }
-        ),
+        )
+        + "\n",
         encoding="utf-8",
     )
+    (tmp_path / "heartwood-exact-output.txt").write_bytes(b"heartwood-agent-exact-ok\n")
     replay_path = tmp_path / "replay.txt"
     replay_path.write_text(
-        "Action set approved (1 action)\nTool terminal exit=0\n",
+        "Action set approved (1 action)\nTool terminal exit=0\nAction set denied (1 action)\n",
         encoding="utf-8",
     )
     inference_path = tmp_path / "inference.json"
@@ -144,6 +169,44 @@ def test_coding_agent_qualification_verifies_complete_acceptance_evidence(
 
     assert summary["tool_execution_count"] == 2
     assert cast(dict[str, bool], summary["checks"])["audit_export_verified"] is True
+    assert cast(dict[str, bool], summary["checks"])["exact_content_verified"] is True
+    assert cast(dict[str, bool], summary["checks"])["grouped_rejection_recorded"] is True
+
+
+def test_coding_agent_qualification_rejects_inexact_or_rejected_output(
+    tmp_path: Path,
+) -> None:
+    module = _module(
+        "verify_coding_agent_e2e_exact_content",
+        _root() / "images/generic/scripts/verify_coding_agent_e2e.py",
+    )
+    verify = cast(Callable[..., dict[str, object]], module.verify_run)
+    events, audit, artifact, replay, inference = _acceptance_files(tmp_path)
+    exact = tmp_path / "heartwood-exact-output.txt"
+
+    exact.write_bytes(b"heartwood-agent-exact-ok")
+    with pytest.raises(ValueError, match="exact-content artifact"):
+        verify(
+            events_path=events,
+            audit_path=audit,
+            artifact_path=artifact,
+            replay_path=replay,
+            inference_path=inference,
+        )
+
+    exact.write_bytes(b"heartwood-agent-exact-ok\n")
+    (tmp_path / "heartwood-rejected-output.txt").write_text(
+        "this-action-must-remain-rejected\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="rejected action modified"):
+        verify(
+            events_path=events,
+            audit_path=audit,
+            artifact_path=artifact,
+            replay_path=replay,
+            inference_path=inference,
+        )
 
 
 def test_coding_agent_qualification_requires_successful_completion(

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -219,7 +219,7 @@ def test_runtime_image_sets_the_release_version_label() -> None:
     assert "ARG HEARTWOOD_VERSION=development" in dockerfile
     assert 'org.opencontainers.image.version="${HEARTWOOD_VERSION}"' in dockerfile
     assert 'variable "HEARTWOOD_VERSION"' in bake
-    assert 'default = "0.2.0-beta.9"' in bake
+    assert 'default = "0.2.0-beta.10"' in bake
     assert bake.count('HEARTWOOD_VERSION = "${HEARTWOOD_VERSION}"') == 2
 
 
@@ -529,7 +529,15 @@ def test_coding_agent_qualification_finds_cli_beside_selected_python(tmp_path: P
     path_bin = tmp_path / "path-bin"
     path_bin.mkdir()
     python = runtime_bin / "python"
-    python.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    python.write_text(
+        """#!/usr/bin/env bash
+if [[ "${1:-}" == "-" && "${2:-}" == */events.jsonl ]]; then
+  printf 'synthetic-pending-action\n'
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
     python.chmod(0o700)
 
     marker = tmp_path / "heartwood-invocations.txt"

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -189,9 +189,9 @@ def test_prerelease_sources_use_semver_and_python_lock_uses_pep440(
 
     assert _release_verifier().source_version_errors(tmp_path, version) == []
 
-    skill_metadata.write_text('{"heartwood.version": "0.2.0-beta.9"}\n', encoding="utf-8")
+    skill_metadata.write_text('{"heartwood.version": "0.2.0-beta.10"}\n', encoding="utf-8")
     assert (
-        "skills/verified/example/metadata.json: 0.2.0-beta.9"
+        "skills/verified/example/metadata.json: 0.2.0-beta.10"
         in _release_verifier().source_version_errors(tmp_path, version)
     )
 

--- a/packages/core-adapter/pyproject.toml
+++ b/packages/core-adapter/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-core-adapter"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Core harness orchestration for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/core-adapter/src/heartwood/core_adapter/__init__.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/detector/pyproject.toml
+++ b/packages/detector/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-detector"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Deterministic, propose-not-commit environment and dataset detection for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/detector/src/heartwood/detector/__init__.py
+++ b/packages/detector/src/heartwood/detector/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "platform_detection_evidence",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/fixtures/pyproject.toml
+++ b/packages/fixtures/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-fixtures"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Synthetic fixture linting for Heartwood tests and replay artifacts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/fixtures/src/heartwood/fixtures/__init__.py
+++ b/packages/fixtures/src/heartwood/fixtures/__init__.py
@@ -12,4 +12,4 @@ from heartwood.fixtures.lint import FixtureFinding, lint_fixture_tree, main
 
 __all__ = ["FixtureFinding", "__version__", "lint_fixture_tree", "main"]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/gateway/pyproject.toml
+++ b/packages/gateway/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-gateway"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Session gateway for Heartwood command and event streams."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/pyproject.toml
+++ b/packages/model-policy/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-model-policy"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Deny-by-default model-call policy evaluation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/src/heartwood/model_policy/__init__.py
+++ b/packages/model-policy/src/heartwood/model_policy/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "normalize_endpoint",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/notebook/pyproject.toml
+++ b/packages/notebook/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-notebook"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Notebook-facing Python API and widget bridge for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/notebook/src/heartwood/notebook/__init__.py
+++ b/packages/notebook/src/heartwood/notebook/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "render_widgets",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/schemas/pyproject.toml
+++ b/packages/schemas/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-schemas"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Versioned typed schemas for Heartwood policy, audit, detection, and skill metadata records."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/schemas/src/heartwood/schemas/__init__.py
+++ b/packages/schemas/src/heartwood/schemas/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "schema_names",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/schemas/tests/test_schema_records.py
+++ b/packages/schemas/tests/test_schema_records.py
@@ -159,14 +159,14 @@ def test_skill_metadata_accepts_skill_md_aliases() -> None:
             "heartwood.phi-risk": "none",
             "heartwood.trust-tier": "verified",
             "heartwood.requires-network": "false",
-            "heartwood.version": "0.2.0-beta.9",
+            "heartwood.version": "0.2.0-beta.10",
             "heartwood.sig": "sigstore:synthetic-bundle",
         }
     )
     assert metadata.dataset_types == ("omop-cdm", "fhir")
     assert metadata.platforms == ("generic", "terra")
     assert metadata.requires_network is False
-    assert metadata.version == "0.2.0-beta.9"
+    assert metadata.version == "0.2.0-beta.10"
 
 
 @pytest.mark.parametrize(

--- a/packages/session/pyproject.toml
+++ b/packages/session/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-session"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Shared session command/event contract for Heartwood interfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/session/src/heartwood/session/__init__.py
+++ b/packages/session/src/heartwood/session/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "validate_session_id",
 ]
 
-__version__ = "0.2.0-beta.9"
+__version__ = "0.2.0-beta.10"

--- a/packages/skills/pyproject.toml
+++ b/packages/skills/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-skills"
-version = "0.2.0-beta.9"
+version = "0.2.0-beta.10"
 description = "Local SKILL.md verification and deterministic skill test harnesses for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/webui/package-lock.json
+++ b/packages/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0-beta.9",
+  "version": "0.2.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heartwood/webui",
-      "version": "0.2.0-beta.9",
+      "version": "0.2.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@stanfordspezi/spezi-web-design-system": "0.20.0",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0-beta.9",
+  "version": "0.2.0-beta.10",
   "private": true,
   "type": "module",
   "description": "Researcher web UI for Heartwood sessions.",

--- a/skills/verified/aggregate-export/SKILL.md
+++ b/skills/verified/aggregate-export/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.9"
+  heartwood.version: "0.2.0-beta.10"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/aggregate-export/metadata.json
+++ b/skills/verified/aggregate-export/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.9",
+  "heartwood.version": "0.2.0-beta.10",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/baseline-model/SKILL.md
+++ b/skills/verified/baseline-model/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.9"
+  heartwood.version: "0.2.0-beta.10"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/baseline-model/metadata.json
+++ b/skills/verified/baseline-model/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.9",
+  "heartwood.version": "0.2.0-beta.10",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/omop-cohort-summary/SKILL.md
+++ b/skills/verified/omop-cohort-summary/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.9"
+  heartwood.version: "0.2.0-beta.10"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/omop-cohort-summary/metadata.json
+++ b/skills/verified/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.9",
+  "heartwood.version": "0.2.0-beta.10",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1472,7 +1472,7 @@ wheels = [
 
 [[package]]
 name = "heartwood-adapters"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/adapters" }
 dependencies = [
     { name = "heartwood-detector" },
@@ -1489,7 +1489,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-audit"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/audit" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1500,7 +1500,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-cli"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/cli" }
 dependencies = [
     { name = "heartwood-gateway" },
@@ -1521,7 +1521,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-compliance"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/compliance" }
 dependencies = [
     { name = "heartwood-audit" },
@@ -1536,7 +1536,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-core-adapter"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/core-adapter" }
 dependencies = [
     { name = "heartwood-adapters" },
@@ -1557,7 +1557,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-detector"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/detector" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1568,12 +1568,12 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-fixtures"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/fixtures" }
 
 [[package]]
 name = "heartwood-gateway"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/gateway" }
 dependencies = [
     { name = "anthropic" },
@@ -1612,7 +1612,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-model-policy"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/model-policy" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1623,7 +1623,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-notebook"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/notebook" }
 dependencies = [
     { name = "heartwood-gateway" },
@@ -1647,7 +1647,7 @@ provides-extras = ["widgets"]
 
 [[package]]
 name = "heartwood-schemas"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/schemas" }
 dependencies = [
     { name = "pydantic" },
@@ -1658,7 +1658,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-session"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/session" }
 dependencies = [
     { name = "pydantic" },
@@ -1669,7 +1669,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-skills"
-version = "0.2.0b9"
+version = "0.2.0b10"
 source = { editable = "packages/skills" }
 dependencies = [
     { name = "heartwood-schemas" },


### PR DESCRIPTION
### :recycle: Current Situation & Problem

Beta 9 validation exposed an unconfigured Carina allocation path, ambiguous model-verification progress, and gaps in exact-output and rejection qualification.

### :gear: Release Notes

- Stop recommendation-only launches before downloads or GPU allocation.
- Complete installer cleanup before reporting success.
- Require byte-exact output and a non-executed rejected action in capable-model qualification.
- Prepare Heartwood 0.2.0 Beta 10.

### :books: Documentation

Clarify Carina setup and verification, Terra compute ordering, persistent-disk recovery, and qualification evidence.

### :white_check_mark: Testing

- Python: 817 tests with 90.05% coverage, Ruff, and mypy
- Web: 73 tests, lint, type checking, and production build
- Exact-commit native packaging and installer smoke suite

### Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).