### PR TITLE
Prepare the Heartwood 0.2.0 Release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ When project direction changes, update the relevant architecture or operations p
 | Project boundary, persistence, and `.heartwood/` layout | [documentation/start/project.md](documentation/start/project.md) |
 | Research-environment, hosted, compatible-service, and Heartwood-managed model workflows | [documentation/models/index.md](documentation/models/index.md) |
 | Deployment responsibilities and platform extension contract | [documentation/operate/index.md](documentation/operate/index.md) |
+| Release support, compatibility, and deprecation policy | [documentation/operate/support.md](documentation/operate/support.md) |
 | Browser workflow | [documentation/use/browser.md](documentation/use/browser.md) |
 | Command reference | [documentation/reference/cli.md](documentation/reference/cli.md) |
 | Readiness states, stable diagnostics, and recovery steps | [documentation/reference/troubleshooting.md](documentation/reference/troubleshooting.md) |

--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ docker run --rm -it \
   --env HOME=/tmp \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
   heartwood --interface web --host 0.0.0.0
 ```
 
 Open [http://127.0.0.1:8767/](http://127.0.0.1:8767/), confirm the project, and choose an authorized model connection. Heartwood treats the mounted host directory as the project and keeps private state in `.heartwood/` inside it.
 
-For the interactive terminal, replace the final command with `heartwood`. The [prerelease documentation](https://schmiedmayerlab.github.io/heartwood/preview/) provides the complete first task and action-review workflow for this prerelease.
+For the interactive terminal, replace the final command with `heartwood`.
+The [stable documentation](https://schmiedmayerlab.github.io/heartwood/) provides the complete first task and action-review workflow for this release.
 
 ## Choose a Setup
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+<!--
+This source file is part of the Heartwood open-source project
+SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+SPDX-License-Identifier: MIT
+-->
+
+# Security Policy
+
+## Report a Vulnerability
+
+Report suspected vulnerabilities through [GitHub private vulnerability reporting](https://github.com/SchmiedmayerLab/heartwood/security/advisories/new).
+Do not open a public issue or include credentials, protected health information, participant-level data, or private platform logs in a report.
+
+Include the affected Heartwood version or image digest, deployment type, impact, and a minimal synthetic reproduction when possible.
+The repository maintainers will acknowledge the report, assess affected supported releases, and coordinate disclosure and remediation through the private advisory.
+
+## Supported Versions
+
+Heartwood is under active pre-1.0 development.
+The current support and compatibility policy is published in [Support and Compatibility](documentation/operate/support.md).
+
+Heartwood does not itself establish institutional approval, HIPAA compliance, or authorization to process controlled data.
+See [Security and Controlled Data](documentation/operate/security.md) for deployment responsibilities and trust boundaries.

--- a/VERSION.toml
+++ b/VERSION.toml
@@ -2,4 +2,4 @@
 # SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 # SPDX-License-Identifier: MIT
 
-version = "0.2.0-beta.10"
+version = "0.2.0"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "GIT_SHA" {
 }
 
 variable "HEARTWOOD_VERSION" {
-  default = "0.2.0-beta.10"
+  default = "0.2.0"
 }
 
 variable "TERRA_BASE_IMAGE" {

--- a/documentation/contribute/releases.md
+++ b/documentation/contribute/releases.md
@@ -20,10 +20,14 @@ Release versions use strict Semantic Versioning without a `v` prefix.
 
 The workflow verifies immutable container candidates, builds and tests native assets, creates a draft with GitHub-generated notes, waits for approval, publishes immutable image tags and the GitHub Release, then publishes versioned documentation.
 
+`CODEOWNERS` identifies the current release maintainer.
+The protected `release` environment is the release-authority boundary and requires explicit approval after the candidate has passed the exact-commit gate.
+Repository administrators may recover interrupted workflows, but they must not replace or retarget an existing immutable release.
+
 ## Stable and Preview Documentation
 
-A stable version updates the `stable` alias and the documentation root.
-A prerelease such as `0.2.0-beta.10` updates the `preview` alias without replacing the stable root.
+A stable version such as `0.2.0` updates the `stable` alias and the documentation root.
+A prerelease such as `0.3.0-beta.1` updates the `preview` alias without replacing the stable root.
 
 The version store is deployed to GitHub Pages and retains immutable version paths.
 Publishing the same version with different content is rejected.
@@ -39,3 +43,5 @@ Each release includes:
 - versioned documentation.
 
 The release workflow marks prerelease versions as GitHub prereleases and never moves a `latest` release designation to them.
+
+See [Support and Compatibility](../operate/support.md) for the maintained release line and pre-1.0 change policy.

--- a/documentation/models/offline.md
+++ b/documentation/models/offline.md
@@ -32,7 +32,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
   heartwood
 ```
 

--- a/documentation/operate/index.md
+++ b/documentation/operate/index.md
@@ -7,6 +7,8 @@ SPDX-License-Identifier: MIT
 # Deploy Heartwood
 
 This section is for platform operators and security reviewers.
+
+Read [Support and Compatibility](support.md) before selecting a release for a maintained deployment.
 A Heartwood deployment combines a versioned application artifact with platform storage, identity, network, secret, compute, model-route, logging, and data-governance controls.
 
 ## Deployment Responsibilities

--- a/documentation/operate/security.md
+++ b/documentation/operate/security.md
@@ -26,6 +26,13 @@ The platform policy can deny unlisted endpoints, but infrastructure egress contr
 
 Confirm data eligibility for the exact endpoint, account, model, and deployment before use.
 
+### Runtime Caches
+
+The supported GPU launcher disables vLLM's optional on-disk outlines cache because its entries are deserialized by the inference process.
+Other runtime and model caches are private to the runtime user and separate from the agent workspace.
+
+Do not enable the outlines disk cache, share runtime caches between users or trust domains, or place cache directories inside an agent-writable project.
+
 ### Credentials
 
 Raw credentials are excluded from project configuration, browser storage, command arguments, durable session events, logs, and audit exports by design.

--- a/documentation/operate/support.md
+++ b/documentation/operate/support.md
@@ -1,0 +1,44 @@
+<!--
+This source file is part of the Heartwood open-source project
+SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+SPDX-License-Identifier: MIT
+-->
+
+# Support and Compatibility
+
+Heartwood uses Semantic Versioning and is under active pre-1.0 development.
+This policy describes project maintenance; it is not a service-level agreement or an institutional support commitment.
+
+## Supported Releases
+
+The latest stable release is the maintained release line.
+The project may issue a patch for that line when a confirmed security, data-integrity, installation, or release defect affects a supported configuration.
+Older stable releases, prereleases, development branches, and moving `edge` image tags do not receive a maintenance window.
+
+Before `1.0.0`, minor releases may change commands, configuration, persisted state, interfaces, platform requirements, and deployment artifacts.
+Release notes and versioned documentation describe the supported behavior for each published version.
+
+## Compatibility
+
+A configuration is supported only when it appears in the versioned documentation for the selected release.
+GPU deployments must also match the release's [GPU compatibility matrix](../reference/gpu-compatibility.md), including the platform, driver, CUDA runtime, model revision, precision, context size, tensor parallelism, and tool parser.
+
+Heartwood validates the published native assets and container candidates for the exact release commit.
+Live-platform qualification is stated separately from continuous-integration validation and expires when a material platform, driver, runtime, model, or policy component changes.
+
+## Changes and Deprecation
+
+Before `1.0.0`, the project favors a coherent interface over preserving unreleased or superseded behavior.
+User-visible breaking changes must update the implementation, tests, release notes, and versioned documentation together.
+A security or data-integrity concern may require immediate removal without a deprecation period.
+
+After `1.0.0`, any change to the support window or deprecation policy requires a documented release decision before the affected release is published.
+
+## Ownership
+
+Repository `CODEOWNERS` identifies the current maintainer responsible for code, bundled Skill, and release review.
+Only protected `main` commits that pass the release gate can be published, and the configured `release` environment requires explicit maintainer approval.
+Repository administrators retain recovery authority for interrupted workflows, compromised credentials, and protected tags.
+
+Report security concerns through the repository [security policy](https://github.com/SchmiedmayerLab/heartwood/security/policy).
+Use [GitHub Issues](https://github.com/SchmiedmayerLab/heartwood/issues) for reproducible defects and compatibility requests that do not contain sensitive information.

--- a/documentation/platforms/carina.md
+++ b/documentation/platforms/carina.md
@@ -41,7 +41,7 @@ Do not use a shared project root itself as the Heartwood project.
 ```bash
 cd heartwood-installation
 curl --fail --location --remote-name \
-  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.10/heartwood-installer
+  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0/heartwood-installer
 chmod 700 heartwood-installer
 ./heartwood-installer --platform carina
 export PATH="$PWD/bin:$PATH"

--- a/documentation/platforms/containers.md
+++ b/documentation/platforms/containers.md
@@ -27,7 +27,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
   heartwood
 ```
 
@@ -44,7 +44,7 @@ docker run --rm -it \
   --env HOME=/tmp \
   -p 127.0.0.1:8767:8767 \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10 \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0 \
   heartwood --interface web --host 0.0.0.0
 ```
 
@@ -63,7 +63,7 @@ docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -v "$PWD:/workspace" \
-  ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-gpu-nvidia \
+  ghcr.io/schmiedmayerlab/heartwood:0.2.0-gpu-nvidia \
   heartwood
 ```
 
@@ -75,10 +75,10 @@ Review the [GPU compatibility matrix](../reference/gpu-compatibility.md) before 
 
 Use immutable release tags for research work:
 
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10` — standard AMD64/ARM64 image;
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-gpu-nvidia` — NVIDIA GPU image;
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra` — Terra CPU image; and
-- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra-gpu-nvidia` — Terra NVIDIA image.
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0` — standard AMD64/ARM64 image;
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-gpu-nvidia` — NVIDIA GPU image;
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra` — Terra CPU image; and
+- `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra-gpu-nvidia` — Terra NVIDIA image.
 
 The moving `edge` tags represent current `main` and are intended for development, not reproducible analyses.
 Release publication verifies candidate digests and manifest shape before creating version tags.

--- a/documentation/platforms/native-linux.md
+++ b/documentation/platforms/native-linux.md
@@ -48,7 +48,7 @@ mkdir -m 700 heartwood-installation
 cd heartwood-installation
 
 curl --fail --location --remote-name \
-  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0-beta.10/heartwood-installer
+  https://github.com/SchmiedmayerLab/heartwood/releases/download/0.2.0/heartwood-installer
 chmod 700 heartwood-installer
 ./heartwood-installer --platform generic
 export PATH="$PWD/bin:$PATH"

--- a/documentation/platforms/terra.md
+++ b/documentation/platforms/terra.md
@@ -42,8 +42,8 @@ Use one of these combinations:
 
 | Model Route | Image | Practical Starting Point |
 |---|---|---|
-| Research environment or hosted service | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra` | 8 CPUs, 30 GB RAM, 50 GB persistent disk |
-| Qualified managed GPU inference | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-beta.10-terra-gpu-nvidia` | 32 CPUs, 120 GB RAM, two T4 GPUs with 16 GB each, 200 GB persistent disk |
+| Research environment or hosted service | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra` | 8 CPUs, 30 GB RAM, 50 GB persistent disk |
+| Qualified managed GPU inference | `ghcr.io/schmiedmayerlab/heartwood:0.2.0-terra-gpu-nvidia` | 32 CPUs, 120 GB RAM, two T4 GPUs with 16 GB each, 200 GB persistent disk |
 
 A hosted model is the shortest first run.
 Use the GPU image for a capable model managed inside the Terra environment.

--- a/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
+++ b/fixtures/synthetic/skills/omop-cohort-summary/SKILL.md
@@ -10,7 +10,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.10"
+  heartwood.version: "0.2.0"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
+++ b/fixtures/synthetic/skills/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.10",
+  "heartwood.version": "0.2.0",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -87,7 +87,7 @@ RUN set -eux; \
     fi; \
     runtime_group="$(id -gn "${HEARTWOOD_RUNTIME_USER}")"; \
     mkdir -p /opt/heartwood /opt/heartwood-vllm /opt/llama.cpp "${HEARTWOOD_WORKDIR}"; \
-    install -d --mode=0755 \
+    install -d --mode=0700 \
       --owner="${HEARTWOOD_RUNTIME_USER}" --group="${runtime_group}" \
       "${HEARTWOOD_RUNTIME_HOME}/.cache" \
       "${HEARTWOOD_RUNTIME_HOME}/.cache/flashinfer" \

--- a/images/gpu/heartwood-vllm
+++ b/images/gpu/heartwood-vllm
@@ -9,6 +9,11 @@ set -euo pipefail
 
 runtime_bin="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
+# vLLM's optional outlines disk cache deserializes local cache entries.
+# Heartwood keeps structured-output compilation in memory until upstream
+# provides a cache format that is safe across trust boundaries.
+export VLLM_V1_USE_OUTLINES_CACHE=0
+
 if [[ "$#" -eq 1 && "$1" == "__heartwood_verify_runtime__" ]]; then
   exec "${runtime_bin}/python" "${runtime_bin}/verify_vllm.py"
 fi

--- a/images/gpu/verify_vllm.py
+++ b/images/gpu/verify_vllm.py
@@ -104,9 +104,11 @@ def _torchscript_calls(package_root: Path) -> list[str]:
         script_names: set[str] = set()
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
-                torch_names.update(
-                    alias.asname or alias.name for alias in node.names if alias.name == "torch"
-                )
+                for alias in node.names:
+                    if alias.name == "torch":
+                        torch_names.add(alias.asname or alias.name)
+                    elif alias.name == "torch.jit" and alias.asname:
+                        jit_names.add(alias.asname)
             elif isinstance(node, ast.ImportFrom) and node.module == "torch":
                 jit_names.update(
                     alias.asname or alias.name for alias in node.names if alias.name == "jit"

--- a/images/gpu/verify_vllm.py
+++ b/images/gpu/verify_vllm.py
@@ -8,12 +8,15 @@
 
 from __future__ import annotations
 
+import ast
 import tomllib
 from importlib import import_module
 from importlib.metadata import distributions, version
 from pathlib import Path
 
 import torch
+import vllm
+import vllm.envs as vllm_envs
 from packaging.utils import canonicalize_name
 from vllm.tool_parsers import ToolParserManager
 
@@ -66,6 +69,14 @@ def main() -> None:
     if cuda_13:
         raise RuntimeError(f"unqualified CUDA 13 packages are installed: {', '.join(cuda_13)}")
 
+    if vllm_envs.VLLM_V1_USE_OUTLINES_CACHE:
+        raise RuntimeError("the vLLM outlines disk cache must remain disabled")
+    torchscript_calls = _torchscript_calls(Path(vllm.__file__).resolve().parent)
+    if torchscript_calls:
+        raise RuntimeError(
+            "the supported vLLM runtime invokes torch.jit.script: " + ", ".join(torchscript_calls)
+        )
+
     import_module("flashinfer")
 
     available_parsers = set(ToolParserManager.list_registered())
@@ -79,6 +90,53 @@ def main() -> None:
         f"vLLM {observed['vllm']}, PyTorch {observed['torch']}, CUDA {torch.version.cuda}; "
         f"tool parsers {', '.join(_REQUIRED_TOOL_PARSERS)}"
     )
+
+
+def _torchscript_calls(package_root: Path) -> list[str]:
+    calls: list[str] = []
+    for path in sorted(package_root.rglob("*.py")):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError) as error:
+            raise RuntimeError(f"unable to inspect packaged vLLM source: {path}") from error
+        torch_names = {"torch"}
+        jit_names: set[str] = set()
+        script_names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                torch_names.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "torch"
+                )
+            elif isinstance(node, ast.ImportFrom) and node.module == "torch":
+                jit_names.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "jit"
+                )
+            elif isinstance(node, ast.ImportFrom) and node.module == "torch.jit":
+                script_names.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "script"
+                )
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            function = node.func
+            direct_call = isinstance(function, ast.Name) and function.id in script_names
+            imported_jit_call = (
+                isinstance(function, ast.Attribute)
+                and function.attr == "script"
+                and isinstance(function.value, ast.Name)
+                and function.value.id in jit_names
+            )
+            torch_call = (
+                isinstance(function, ast.Attribute)
+                and function.attr == "script"
+                and isinstance(function.value, ast.Attribute)
+                and function.value.attr == "jit"
+                and isinstance(function.value.value, ast.Name)
+                and function.value.value.id in torch_names
+            )
+            if direct_call or imported_jit_call or torch_call:
+                calls.append(f"{path.relative_to(package_root)}:{node.lineno}")
+    return calls
 
 
 def _runtime_contract() -> dict[str, object]:

--- a/packages/adapters/pyproject.toml
+++ b/packages/adapters/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-adapters"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Adapter service provider interfaces and conformance checks for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/adapters/src/heartwood/adapters/__init__.py
+++ b/packages/adapters/src/heartwood/adapters/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "assert_registry_adapter_conforms",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/adapters/src/heartwood/adapters/conformance.py
+++ b/packages/adapters/src/heartwood/adapters/conformance.py
@@ -64,7 +64,7 @@ def assert_data_source_adapter_conforms(
 def assert_registry_adapter_conforms(
     adapter: RegistryAdapter,
     skill_id: str = "heartwood.synthetic.omop-cohort-summary",
-    version: str = "0.2.0-beta.10",
+    version: str = "0.2.0",
 ) -> None:
     """Assert the shared minimum contract for registry adapters."""
     assert adapter.registry_id

--- a/packages/adapters/tests/test_conformance.py
+++ b/packages/adapters/tests/test_conformance.py
@@ -119,7 +119,7 @@ class FakeRegistryAdapter:
     def verify_skill(self, reference: SkillReference) -> RegistryVerification:
         """Verify the synthetic skill reference."""
         return RegistryVerification(
-            verified=reference.version == "0.2.0-beta.10",
+            verified=reference.version == "0.2.0",
             reason="synthetic fixture registry result",
         )
 

--- a/packages/audit/pyproject.toml
+++ b/packages/audit/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-audit"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Hash-chained audit logging for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/audit/src/heartwood/audit/__init__.py
+++ b/packages/audit/src/heartwood/audit/__init__.py
@@ -18,4 +18,4 @@ __all__ = [
     "scrub_json_value",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-cli"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "The heartwood command-line interface — the primary interaction surface."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/cli/src/heartwood/cli/__init__.py
+++ b/packages/cli/src/heartwood/cli/__init__.py
@@ -72,7 +72,7 @@ from heartwood.session import (
 
 __all__ = ["__version__", "main"]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"
 
 _PROG = "heartwood"
 

--- a/packages/compliance/pyproject.toml
+++ b/packages/compliance/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-compliance"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Synthetic-only reviewer packet and audit bundle generation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/compliance/src/heartwood/compliance/__init__.py
+++ b/packages/compliance/src/heartwood/compliance/__init__.py
@@ -12,4 +12,4 @@ from heartwood.compliance._reviewer_packet import ReviewerPacket, ReviewerPacket
 
 __all__ = ["ReviewerPacket", "ReviewerPacketGenerator", "__version__"]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -143,7 +143,7 @@ def test_platform_image_adds_heartwood_without_replacing_terra_runtime() -> None
     assert "HEARTWOOD_IMAGE_FLAVOR=${HEARTWOOD_IMAGE_FLAVOR}" in dockerfile
     assert "HEARTWOOD_PLATFORM=${HEARTWOOD_PLATFORM}" in dockerfile
     assert "HEARTWOOD_PLATFORM_HOME=${HEARTWOOD_RUNTIME_HOME}" in dockerfile
-    assert "install -d --mode=0755 \\" in dockerfile
+    assert "install -d --mode=0700 \\" in dockerfile
     assert '"${HEARTWOOD_RUNTIME_HOME}/.cache/flashinfer"' in dockerfile
     assert 'dockerfile = "images/Dockerfile"' in bake
     assert 'target = "runtime-image"' in bake
@@ -219,7 +219,7 @@ def test_runtime_image_sets_the_release_version_label() -> None:
     assert "ARG HEARTWOOD_VERSION=development" in dockerfile
     assert 'org.opencontainers.image.version="${HEARTWOOD_VERSION}"' in dockerfile
     assert 'variable "HEARTWOOD_VERSION"' in bake
-    assert 'default = "0.2.0-beta.10"' in bake
+    assert 'default = "0.2.0"' in bake
     assert bake.count('HEARTWOOD_VERSION = "${HEARTWOOD_VERSION}"') == 2
 
 
@@ -867,11 +867,20 @@ def test_vllm_advisory_exceptions_remain_isolated_to_gpu_dependencies() -> None:
     lock = root / "images/gpu/vllm-requirements.txt"
     input_file = root / "images/gpu/vllm.in"
     gpu_dependencies = {lock, input_file}
+    tracked_files = subprocess.run(
+        ["git", "ls-files"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
     dependency_files = {
-        root / "uv.lock",
-        *root.rglob("pyproject.toml"),
-        *root.rglob("*requirements*.txt"),
-        *root.rglob("*.in"),
+        root / path
+        for path in tracked_files
+        if path == "uv.lock"
+        or Path(path).name == "pyproject.toml"
+        or "requirements" in Path(path).name
+        or Path(path).suffix == ".in"
     }
     declaration = re.compile(
         r'(?im)(?:^name\s*=\s*["\']|^|["\'\s])(diskcache|torch|vllm)(?:["\'\s<>=!~@\[])'
@@ -891,6 +900,19 @@ def test_vllm_advisory_exceptions_remain_isolated_to_gpu_dependencies() -> None:
     assert "torch-2.11.0%2Bcu129-cp312-cp312-manylinux_2_28_x86_64.whl" in (
         input_file.read_text(encoding="utf-8")
     )
+    wrapper = _read("images/gpu/heartwood-vllm")
+    verifier = _read("images/gpu/verify_vllm.py")
+    dockerfile = _read("images/Dockerfile")
+    carina = _read("deploy/carina/bootstrap.sh")
+
+    assert "export VLLM_V1_USE_OUTLINES_CACHE=0" in wrapper
+    assert "vllm_envs.VLLM_V1_USE_OUTLINES_CACHE" in verifier
+    assert "_torchscript_calls" in verifier
+    assert "torch.jit.script" in verifier
+    assert "install -d --mode=0700 \\\n" in dockerfile
+    assert '"${HEARTWOOD_RUNTIME_HOME}/.cache/vllm";' in dockerfile
+    assert 'chmod 700 "${installer_directories[@]}"' in carina
+    assert 'XDG_CACHE_HOME="${installer_state}/cache/xdg"' in carina
 
 
 def test_isolated_smoke_uses_real_openhands_sdk_without_weights() -> None:

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import importlib.util
 import json
@@ -913,6 +914,28 @@ def test_vllm_advisory_exceptions_remain_isolated_to_gpu_dependencies() -> None:
     assert '"${HEARTWOOD_RUNTIME_HOME}/.cache/vllm";' in dockerfile
     assert 'chmod 700 "${installer_directories[@]}"' in carina
     assert 'XDG_CACHE_HOME="${installer_state}/cache/xdg"' in carina
+
+
+def test_vllm_verifier_detects_aliased_torchscript_import(tmp_path: Path) -> None:
+    verifier_path = _repo_root() / "images/gpu/verify_vllm.py"
+    source = verifier_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    helper = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_torchscript_calls"
+    )
+    namespace: dict[str, Any] = {"ast": ast, "Path": Path}
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), verifier_path, "exec"), namespace)
+
+    package_root = tmp_path / "vllm"
+    package_root.mkdir()
+    (package_root / "aliased.py").write_text(
+        "import torch.jit as jit\njit.script(lambda value: value)\n",
+        encoding="utf-8",
+    )
+
+    assert namespace["_torchscript_calls"](package_root) == ["aliased.py:2"]
 
 
 def test_isolated_smoke_uses_real_openhands_sdk_without_weights() -> None:

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -130,6 +130,21 @@ def test_current_release_guides_match_declared_version() -> None:
     assert _release_verifier().source_version_errors(Path.cwd(), _declared_version()) == []
 
 
+def test_support_and_security_policies_define_current_ownership() -> None:
+    security = Path("SECURITY.md").read_text(encoding="utf-8")
+    support = Path("documentation/operate/support.md").read_text(encoding="utf-8")
+    releases = Path("documentation/contribute/releases.md").read_text(encoding="utf-8")
+    navigation = Path("zensical.toml").read_text(encoding="utf-8")
+
+    assert "GitHub private vulnerability reporting" in security
+    assert "latest stable release is the maintained release line" in support
+    assert "Before `1.0.0`" in support
+    assert "Repository `CODEOWNERS` identifies the current maintainer" in support
+    assert "configured `release` environment requires explicit maintainer approval" in support
+    assert "protected `release` environment is the release-authority boundary" in releases
+    assert '"Support and Compatibility" = "operate/support.md"' in navigation
+
+
 def test_prerelease_sources_use_semver_and_python_lock_uses_pep440(
     tmp_path: Path,
 ) -> None:
@@ -189,9 +204,9 @@ def test_prerelease_sources_use_semver_and_python_lock_uses_pep440(
 
     assert _release_verifier().source_version_errors(tmp_path, version) == []
 
-    skill_metadata.write_text('{"heartwood.version": "0.2.0-beta.10"}\n', encoding="utf-8")
+    skill_metadata.write_text('{"heartwood.version": "0.2.0"}\n', encoding="utf-8")
     assert (
-        "skills/verified/example/metadata.json: 0.2.0-beta.10"
+        "skills/verified/example/metadata.json: 0.2.0"
         in _release_verifier().source_version_errors(tmp_path, version)
     )
 

--- a/packages/core-adapter/pyproject.toml
+++ b/packages/core-adapter/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-core-adapter"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Core harness orchestration for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/core-adapter/src/heartwood/core_adapter/__init__.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/detector/pyproject.toml
+++ b/packages/detector/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-detector"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Deterministic, propose-not-commit environment and dataset detection for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/detector/src/heartwood/detector/__init__.py
+++ b/packages/detector/src/heartwood/detector/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "platform_detection_evidence",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/fixtures/pyproject.toml
+++ b/packages/fixtures/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-fixtures"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Synthetic fixture linting for Heartwood tests and replay artifacts."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/fixtures/src/heartwood/fixtures/__init__.py
+++ b/packages/fixtures/src/heartwood/fixtures/__init__.py
@@ -12,4 +12,4 @@ from heartwood.fixtures.lint import FixtureFinding, lint_fixture_tree, main
 
 __all__ = ["FixtureFinding", "__version__", "lint_fixture_tree", "main"]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/gateway/pyproject.toml
+++ b/packages/gateway/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-gateway"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Session gateway for Heartwood command and event streams."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/pyproject.toml
+++ b/packages/model-policy/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-model-policy"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Deny-by-default model-call policy evaluation for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/model-policy/src/heartwood/model_policy/__init__.py
+++ b/packages/model-policy/src/heartwood/model_policy/__init__.py
@@ -23,4 +23,4 @@ __all__ = [
     "normalize_endpoint",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/notebook/pyproject.toml
+++ b/packages/notebook/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-notebook"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Notebook-facing Python API and widget bridge for Heartwood sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/notebook/src/heartwood/notebook/__init__.py
+++ b/packages/notebook/src/heartwood/notebook/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "render_widgets",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/schemas/pyproject.toml
+++ b/packages/schemas/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-schemas"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Versioned typed schemas for Heartwood policy, audit, detection, and skill metadata records."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/schemas/src/heartwood/schemas/__init__.py
+++ b/packages/schemas/src/heartwood/schemas/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "schema_names",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/schemas/tests/test_schema_records.py
+++ b/packages/schemas/tests/test_schema_records.py
@@ -159,14 +159,14 @@ def test_skill_metadata_accepts_skill_md_aliases() -> None:
             "heartwood.phi-risk": "none",
             "heartwood.trust-tier": "verified",
             "heartwood.requires-network": "false",
-            "heartwood.version": "0.2.0-beta.10",
+            "heartwood.version": "0.2.0",
             "heartwood.sig": "sigstore:synthetic-bundle",
         }
     )
     assert metadata.dataset_types == ("omop-cdm", "fhir")
     assert metadata.platforms == ("generic", "terra")
     assert metadata.requires_network is False
-    assert metadata.version == "0.2.0-beta.10"
+    assert metadata.version == "0.2.0"
 
 
 @pytest.mark.parametrize(

--- a/packages/session/pyproject.toml
+++ b/packages/session/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-session"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Shared session command/event contract for Heartwood interfaces."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/session/src/heartwood/session/__init__.py
+++ b/packages/session/src/heartwood/session/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "validate_session_id",
 ]
 
-__version__ = "0.2.0-beta.10"
+__version__ = "0.2.0"

--- a/packages/skills/pyproject.toml
+++ b/packages/skills/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "heartwood-skills"
-version = "0.2.0-beta.10"
+version = "0.2.0"
 description = "Local SKILL.md verification and deterministic skill test harnesses for Heartwood."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/webui/package-lock.json
+++ b/packages/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heartwood/webui",
-      "version": "0.2.0-beta.10",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@stanfordspezi/spezi-web-design-system": "0.20.0",
@@ -10432,9 +10432,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10451,7 +10451,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heartwood/webui",
-  "version": "0.2.0-beta.10",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Researcher web UI for Heartwood sessions.",
@@ -33,7 +33,7 @@
   "overrides": {
     "esbuild": "0.28.1",
     "next": "16.2.11",
-    "postcss": "8.5.10",
+    "postcss": "8.5.19",
     "sharp": "0.35.3"
   },
   "devDependencies": {

--- a/skills/verified/aggregate-export/SKILL.md
+++ b/skills/verified/aggregate-export/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.10"
+  heartwood.version: "0.2.0"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/aggregate-export/metadata.json
+++ b/skills/verified/aggregate-export/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.10",
+  "heartwood.version": "0.2.0",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/baseline-model/SKILL.md
+++ b/skills/verified/baseline-model/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.10"
+  heartwood.version: "0.2.0"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/baseline-model/metadata.json
+++ b/skills/verified/baseline-model/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.10",
+  "heartwood.version": "0.2.0",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/skills/verified/omop-cohort-summary/SKILL.md
+++ b/skills/verified/omop-cohort-summary/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   heartwood.phi-risk: "none"
   heartwood.trust-tier: "verified"
   heartwood.requires-network: "false"
-  heartwood.version: "0.2.0-beta.10"
+  heartwood.version: "0.2.0"
   heartwood.sig: "sigstore:synthetic-fixture"
 ---
 

--- a/skills/verified/omop-cohort-summary/metadata.json
+++ b/skills/verified/omop-cohort-summary/metadata.json
@@ -5,6 +5,6 @@
   "heartwood.phi-risk": "none",
   "heartwood.trust-tier": "verified",
   "heartwood.requires-network": "false",
-  "heartwood.version": "0.2.0-beta.10",
+  "heartwood.version": "0.2.0",
   "heartwood.sig": "sigstore:synthetic-fixture"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1472,7 +1472,7 @@ wheels = [
 
 [[package]]
 name = "heartwood-adapters"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/adapters" }
 dependencies = [
     { name = "heartwood-detector" },
@@ -1489,7 +1489,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-audit"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/audit" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1500,7 +1500,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-cli"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/cli" }
 dependencies = [
     { name = "heartwood-gateway" },
@@ -1521,7 +1521,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-compliance"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/compliance" }
 dependencies = [
     { name = "heartwood-audit" },
@@ -1536,7 +1536,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-core-adapter"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/core-adapter" }
 dependencies = [
     { name = "heartwood-adapters" },
@@ -1557,7 +1557,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-detector"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/detector" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1568,12 +1568,12 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-fixtures"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/fixtures" }
 
 [[package]]
 name = "heartwood-gateway"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/gateway" }
 dependencies = [
     { name = "anthropic" },
@@ -1612,7 +1612,7 @@ requires-dist = [
 
 [[package]]
 name = "heartwood-model-policy"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/model-policy" }
 dependencies = [
     { name = "heartwood-schemas" },
@@ -1623,7 +1623,7 @@ requires-dist = [{ name = "heartwood-schemas", editable = "packages/schemas" }]
 
 [[package]]
 name = "heartwood-notebook"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/notebook" }
 dependencies = [
     { name = "heartwood-gateway" },
@@ -1647,7 +1647,7 @@ provides-extras = ["widgets"]
 
 [[package]]
 name = "heartwood-schemas"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/schemas" }
 dependencies = [
     { name = "pydantic" },
@@ -1658,7 +1658,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-session"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/session" }
 dependencies = [
     { name = "pydantic" },
@@ -1669,7 +1669,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.12" }]
 
 [[package]]
 name = "heartwood-skills"
-version = "0.2.0b10"
+version = "0.2.0"
 source = { editable = "packages/skills" }
 dependencies = [
     { name = "heartwood-schemas" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -45,6 +45,7 @@ nav = [
     ] },
     { "Operate Heartwood" = [
         { "Deployment Responsibilities" = "operate/index.md" },
+        { "Support and Compatibility" = "operate/support.md" },
         { "Security and Controlled Data" = "operate/security.md" },
         { "Add a Platform" = "operate/platform-integration.md" },
     ] },


### PR DESCRIPTION
### :recycle: Current situation & Problem

Heartwood needs enforceable mitigations for the remaining GPU runtime advisories and a clear support and security policy before the first stable 0.2 release. This advances #34 and #48.

### :gear: Release Notes

- Disable vLLM's optional outlines disk cache and reject packaged vLLM TorchScript use.
- Keep runtime caches private and define current support, compatibility, security-reporting, and release ownership policies.
- Promote release-owned metadata, artifacts, dependencies, and documentation to `0.2.0`.

### :books: Documentation

Adds the repository security policy and Support and Compatibility guide, and updates stable release and platform references for `0.2.0`.

### :white_check_mark: Testing

Python, web unit and browser tests, gateway and notebook smoke tests, strict documentation build, REUSE, release version gate, native installer suite, and clean Ubuntu 24.04 installation and inference smoke.

### Code of Conduct & Contributing Guidelines

- [x] I agree to follow this project's Code of Conduct and Contributing Guidelines.