### PR TITLE
Enforce Single-Writer Session Recovery

### DIFF
--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -61,7 +61,7 @@ jobs:
         run: npm run license:check
       - name: Audit npm dependencies
         working-directory: packages/webui
-        run: npm audit --audit-level=moderate
+        run: npm audit --omit=dev --audit-level=moderate
       - name: Install Playwright Chromium
         working-directory: packages/webui
         run: npx playwright install --with-deps chromium

--- a/documentation/architecture/sessions-audit.md
+++ b/documentation/architecture/sessions-audit.md
@@ -40,6 +40,21 @@ Session identifiers are validated before any state path is created.
 Read-only replay returns no events for a new session without initializing the project.
 The first mutating command registers the session and creates private state.
 
+The gateway acquires an interprocess writer lease before mutating a session and retains it until that gateway closes the session service.
+Another process may replay the completed event stream, but it cannot append commands to the same session until the owner exits.
+Distinct sessions have independent leases.
+
+Every command has an opaque identifier and a durable receipt.
+An exact retry of a completed command returns its original event range without repeating a model call, confirmation callback, or tool action.
+Reusing the identifier with different command content is rejected.
+If a process stops after command acceptance but before completion is recorded, Heartwood marks the outcome as uncertain and refuses to execute that identifier again automatically.
+The session rejects further mutation so a second approval or task cannot repeat an uncertain side effect.
+After replaying and verifying the available evidence, continue in a new session.
+
+Each session event and its corresponding audit record are committed through a private recovery journal.
+After an interrupted append, the next writer verifies the journal, hash links, and existing records before completing only the missing write.
+Malformed or inconsistent recovery state fails closed.
+
 ## Action Decisions
 
 OpenHands can supply several proposed tool calls through one confirmation callback.
@@ -48,7 +63,8 @@ Heartwood displays every member as one action set and applies one decision to th
 ## Audit Integrity
 
 Audit records are chained so replay and export can detect modification, reordering, or missing records within the available chain.
-Each content-minimized audit record also authenticates the corresponding complete session event by hash; replay requires matching counts, sequence, type, time, chain link, and event hash and fails closed after tampering or a partial two-file write.
+Each content-minimized audit record also authenticates the corresponding complete session event by hash; replay requires matching counts, sequence, type, time, chain link, and event hash.
+The recovery journal repairs a verified interrupted two-file append before replay, while tampered or unexplained mismatches fail closed.
 The chain alone cannot prove that an intact suffix was not deleted; deployments that require truncation detection must checkpoint the terminal hash or event count in independently retained storage.
 The export path is itself recorded as an event.
 
@@ -64,5 +80,7 @@ Condenser calls use a separate usage identifier and do not bypass model-route po
 
 ## Move Between Interfaces
 
-Use one writer for a session at a time.
-Close or stop the active terminal, browser gateway, or notebook writer before continuing the same session from another process; use distinct session identifiers when interfaces must remain active side by side.
+Heartwood enforces one writer for each session.
+Close or stop the active terminal, browser gateway, or notebook writer before continuing that session from another process.
+The next process can then acquire the lease and continue the same authoritative event sequence.
+Use distinct session identifiers when interfaces must remain active side by side.

--- a/documentation/architecture/sessions-audit.md
+++ b/documentation/architecture/sessions-audit.md
@@ -43,6 +43,12 @@ The first mutating command registers the session and creates private state.
 The gateway acquires an interprocess writer lease before mutating a session and retains it until that gateway closes the session service.
 Another process may replay the completed event stream, but it cannot append commands to the same session until the owner exits.
 Distinct sessions have independent leases.
+Mutation acquires the writer lease before the paired-snapshot lock; recovery and replay never hold the snapshot lock while waiting for a writer lease.
+This fixed ordering prevents deadlock as new gateway workers and presentation adapters reuse the store.
+
+Session state must reside on storage that implements process-shared native advisory locks.
+Heartwood disables existence-lock fallback because it cannot provide the same automatic release after process termination.
+Local disks, attached persistent disks, and qualified project filesystems are the intended locations; object-store and file-transfer mounts are not session stores unless their native-lock behavior has been qualified.
 
 Every command has an opaque identifier and a durable receipt.
 An exact retry of a completed command returns its original event range without repeating a model call, confirmation callback, or tool action.

--- a/documentation/architecture/system.md
+++ b/documentation/architecture/system.md
@@ -57,8 +57,13 @@ Generic, Terra, and Carina behavior differs only through these boundaries and st
 
 ## Process Ownership
 
-One Heartwood process should write a given session at a time.
-Project configuration uses a scoped interprocess lock, but session event stores do not provide a general multi-process writer lock.
+Project configuration writes use a project-scoped interprocess lock.
+Session mutation uses a separate interprocess lease for each session, owned by the gateway process that first handles a command.
+The lease remains active until that session service closes.
 
-The browser gateway owns its sessions while running.
-Do not open the same session for concurrent mutation from another process.
+Command receipts make completed requests idempotent across retries and restarts.
+A paired event-and-audit recovery journal completes verified interrupted appends without duplicating either record.
+Writer metadata left by a stopped process is treated as stale only after the operating-system lock can be acquired; the new owner then validates recovery state before continuing.
+
+The browser, terminal, and notebook interfaces therefore cannot fork one session by writing from separate processes.
+They may continue the session sequentially after the current owner stops, or use distinct session identifiers concurrently.

--- a/documentation/reference/configuration.md
+++ b/documentation/reference/configuration.md
@@ -53,4 +53,6 @@ Do not add these to shell history or documentation with real secret values.
 ## Concurrency
 
 Configuration updates are serialized across concurrent Heartwood processes.
-Session event files assume one writer process per session; use separate session identifiers or one owning gateway when multiple interfaces are needed.
+Each active session also has an enforced writer lease.
+Stop the process that owns a session before continuing it from another interface, or use separate session identifiers for simultaneous work.
+Do not delete internal lock, command-receipt, or recovery-journal files.

--- a/documentation/reference/troubleshooting.md
+++ b/documentation/reference/troubleshooting.md
@@ -165,6 +165,16 @@ Use the terminal or the Terra notebook interface instead of constructing a proxy
 
 Do not work around a proxy failure by binding the gateway publicly without authentication.
 
+## Session Ownership and Interrupted Commands
+
+If Heartwood reports that a session is active in another process, stop the terminal, browser server, or notebook kernel that owns it and try again.
+Do not remove `.writer.lock` or `.writer.json`; the operating-system lock determines ownership, and Heartwood reclaims stale metadata after the prior process has exited.
+
+A completed request can be retried with the same command identifier and content without repeating model or tool work.
+If Heartwood reports that a command was interrupted after acceptance, replay the session and verify the project files and audit records before continuing.
+Then continue in a new session; the interrupted session remains read-only so an uncertain action cannot be repeated.
+Do not edit or remove files below the session's `.commands/` directory or its recovery journal.
+
 ## Collect Safe Diagnostics
 
 Share the Heartwood version, `heartwood doctor --json`, platform, image tag or digest, failing `HW-*` code, and a minimal synthetic reproduction.

--- a/documentation/reference/troubleshooting.md
+++ b/documentation/reference/troubleshooting.md
@@ -169,6 +169,8 @@ Do not work around a proxy failure by binding the gateway publicly without authe
 
 If Heartwood reports that a session is active in another process, stop the terminal, browser server, or notebook kernel that owns it and try again.
 Do not remove `.writer.lock` or `.writer.json`; the operating-system lock determines ownership, and Heartwood reclaims stale metadata after the prior process has exited.
+If Heartwood reports that the project storage does not support required process locks, move the complete project to a native local, attached persistent, or qualified project filesystem.
+Do not move only `.heartwood/`, and do not use an object-store mount as session storage.
 
 A completed request can be retried with the same command identifier and content without repeating model or tool work.
 If Heartwood reports that a command was interrupted after acceptance, replay the session and verify the project files and audit records before continuing.

--- a/documentation/start/project.md
+++ b/documentation/start/project.md
@@ -51,6 +51,8 @@ On supported workstations, Heartwood can store a token in the operating-system c
 | Stanford Carina | A dedicated writable directory in approved project storage |
 
 Job scratch, temporary container filesystems, and `/tmp` are not durable project locations.
+The project location must also support native process-shared advisory file locks so an interrupted process releases session ownership automatically.
+Use the attached Terra persistent disk or approved Carina project storage rather than an object-store mount for `.heartwood/`.
 
 ## Back Up and Share Carefully
 

--- a/documentation/use/index.md
+++ b/documentation/use/index.md
@@ -41,7 +41,7 @@ If a task should not use the network, parent directories, or particular files, s
 
 All interfaces use the project selected by the process current directory.
 They do not maintain separate browser, terminal, or notebook workspaces.
-They can continue the same session sequentially, but one process should write a session at a time.
+They can continue the same session sequentially, and Heartwood prevents separate processes from writing that session at the same time.
 Stop the active writer before moving a session to another interface, or choose distinct session identifiers for simultaneous work.
 
 ## Verify Before Trusting the Result

--- a/packages/audit/src/heartwood/audit/_log.py
+++ b/packages/audit/src/heartwood/audit/_log.py
@@ -41,11 +41,20 @@ class AuditLog:
 
     def read(self) -> tuple[AuditEvent, ...]:
         """Read all events from disk."""
-        if not self.path.exists():
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            descriptor = os.open(self.path, flags)
+        except FileNotFoundError:
             return ()
+        try:
+            content = bytearray()
+            while chunk := os.read(descriptor, 64 * 1024):
+                content.extend(chunk)
+        finally:
+            os.close(descriptor)
         return tuple(
             AuditEvent.model_validate_json(line)
-            for line in self.path.read_text(encoding="utf-8").splitlines()
+            for line in content.decode("utf-8").splitlines()
             if line
         )
 
@@ -58,6 +67,38 @@ class AuditLog:
         payload: dict[str, JsonValue] | None = None,
     ) -> AuditEvent:
         """Append a scrubbed event and return the persisted record."""
+        event = self.prepare(
+            session_id=session_id,
+            event_type=event_type,
+            occurred_at=occurred_at,
+            payload=payload,
+        )
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(self.path, flags, 0o600)
+        try:
+            os.fchmod(descriptor, 0o600)
+            content = (event.model_dump_json() + "\n").encode("utf-8")
+            remaining = memoryview(content)
+            while remaining:
+                written = os.write(descriptor, remaining)
+                if written <= 0:  # pragma: no cover - operating-system invariant
+                    raise OSError("audit append made no progress")
+                remaining = remaining[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        return event
+
+    def prepare(
+        self,
+        *,
+        session_id: str,
+        event_type: str,
+        occurred_at: str,
+        payload: dict[str, JsonValue] | None = None,
+    ) -> AuditEvent:
+        """Build the next verified audit record without persisting it."""
         events = self.read()
         if events:
             self.verify(events)
@@ -77,12 +118,6 @@ class AuditLog:
             event_hash=None,
         )
         event = event.model_copy(update={"event_hash": compute_event_hash(event)})
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
-        descriptor = os.open(self.path, flags, 0o600)
-        os.fchmod(descriptor, 0o600)
-        with os.fdopen(descriptor, "a", encoding="utf-8") as file:
-            file.write(event.model_dump_json() + "\n")
         return event
 
     def verify(self, events: tuple[AuditEvent, ...] | None = None) -> None:

--- a/packages/cli/src/heartwood/cli/__init__.py
+++ b/packages/cli/src/heartwood/cli/__init__.py
@@ -40,6 +40,7 @@ from heartwood.gateway import (
     DEFAULT_SESSION_ID,
     MODEL_SOURCE_OPTIONS,
     ActionSettingsError,
+    CommandConflictError,
     CredentialStoreError,
     DeploymentReadiness,
     GatewayAsgiApp,
@@ -55,6 +56,8 @@ from heartwood.gateway import (
     ProjectContext,
     ProjectStateError,
     SessionGateway,
+    SessionOwnershipError,
+    SessionRecoveryError,
     SkillSettingsError,
     StartupPlan,
     custom_model_connection_requires_token,
@@ -67,6 +70,7 @@ from heartwood.session import (
     JsonValue,
     SessionCommand,
     SessionEvent,
+    new_command_id,
     validate_session_id,
 )
 
@@ -391,6 +395,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Run ``heartwood`` and return a process exit code."""
     try:
         return _main(argv)
+    except (CommandConflictError, SessionOwnershipError, SessionRecoveryError) as error:
+        print(f"Session unavailable: {error}", file=sys.stderr)
+        return 75
     except KeyboardInterrupt:
         print("\nInterrupted.", file=sys.stderr)
         return 130
@@ -1552,7 +1559,6 @@ def _submit_task(
     kind: CommandKind = CommandKind.CHAT,
 ) -> int:
     command = _command(
-        gateway,
         session_id=session_id,
         kind=kind,
         payload={"prompt": prompt},
@@ -1566,7 +1572,7 @@ def _submit_task(
 
 
 def _submit_simple(gateway: SessionGateway, *, session_id: str, kind: CommandKind) -> int:
-    events = gateway.handle(_command(gateway, session_id=session_id, kind=kind)).events
+    events = gateway.handle(_command(session_id=session_id, kind=kind)).events
     print(_format_transcript(events))
     return _event_exit_code(events)
 
@@ -1808,9 +1814,7 @@ def _handle_audit_export(
     session_id: str,
     output: Path | None,
 ) -> int:
-    events = gateway.handle(
-        _command(gateway, session_id=session_id, kind=CommandKind.AUDIT_EXPORT)
-    ).events
+    events = gateway.handle(_command(session_id=session_id, kind=CommandKind.AUDIT_EXPORT)).events
     if output is not None:
         export_path = Path(str(events[-1].payload["path"]))
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -1840,15 +1844,13 @@ def _handle_serve(
 
 
 def _command(
-    gateway: SessionGateway,
     *,
     session_id: str,
     kind: CommandKind,
     payload: dict[str, JsonValue] | None = None,
 ) -> SessionCommand:
-    sequence = len(gateway.replay_events(session_id=session_id))
     return SessionCommand(
-        command_id=f"{session_id}-{kind.value}-{sequence:06d}",
+        command_id=new_command_id(session_id, kind),
         session_id=session_id,
         kind=kind,
         actor_id="human",

--- a/packages/cli/src/heartwood/cli/_interactive.py
+++ b/packages/cli/src/heartwood/cli/_interactive.py
@@ -16,7 +16,14 @@ from datetime import UTC, datetime
 from typing import cast
 
 from heartwood.gateway import ModelSettingsError, SessionGateway
-from heartwood.session import CommandKind, EventKind, JsonValue, SessionCommand, SessionEvent
+from heartwood.session import (
+    CommandKind,
+    EventKind,
+    JsonValue,
+    SessionCommand,
+    SessionEvent,
+    new_command_id,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -183,9 +190,8 @@ class InteractiveSession:
         kind: CommandKind,
         payload: dict[str, JsonValue] | None = None,
     ) -> tuple[SessionEvent, ...]:
-        sequence = len(self.gateway.replay_events(session_id=self.session_id))
         command = SessionCommand(
-            command_id=f"{self.session_id}-{kind.value}-{sequence:06d}",
+            command_id=new_command_id(self.session_id, kind),
             session_id=self.session_id,
             kind=kind,
             actor_id="human",

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import io
 import json
@@ -1467,6 +1468,29 @@ def test_cli_reports_active_browser_session_without_traceback(
         captured.err
     )
     browser_gateway.stop()
+
+
+def test_cli_reports_unsupported_session_storage_without_traceback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def native_lock_unavailable(_descriptor: int) -> bool:
+        raise OSError(errno.ENOSYS, "synthetic unsupported filesystem")
+
+    project = tmp_path / "analysis"
+    project.mkdir()
+    _install_deterministic_gateway(monkeypatch)
+    monkeypatch.setattr("filelock._unix._lock_fd_nonblocking", native_lock_unavailable)
+
+    assert _run(project, monkeypatch, ["--session-id", "review", "pause"]) == 75
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert (
+        "Session unavailable: session storage does not support required process locks: review"
+        in captured.err
+    )
 
 
 def test_serve_requires_built_assets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/cli/tests/test_cli.py
+++ b/packages/cli/tests/test_cli.py
@@ -1423,6 +1423,52 @@ def test_audit_export_uses_project_sessions(
     assert "Audit export" in capsys.readouterr().out
 
 
+def test_cli_reports_active_browser_session_without_traceback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "analysis"
+    project.mkdir()
+    _install_deterministic_gateway(monkeypatch)
+    browser_gateway = RealSessionGateway(
+        project=ProjectContext(project),
+        env={},
+        backend_id="deterministic",
+    )
+    browser = RestGateway(browser_gateway)
+    command = json.dumps(
+        {
+            "schema_version": "heartwood.session-command.v1",
+            "command_id": "browser-pause",
+            "session_id": "review",
+            "kind": "pause",
+            "actor_id": "browser",
+            "created_at": "2026-01-01T00:00:00Z",
+            "payload": {},
+        }
+    )
+    assert (
+        browser.handle(
+            RestRequest(
+                method="POST",
+                path="/sessions/review/commands",
+                body=command,
+            )
+        ).status_code
+        == 200
+    )
+
+    assert _run(project, monkeypatch, ["--session-id", "review", "resume"]) == 75
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Session unavailable: session review is active in another Heartwood process" in (
+        captured.err
+    )
+    browser_gateway.stop()
+
+
 def test_serve_requires_built_assets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(SystemExit, match="web UI assets not found"):
         _run(

--- a/packages/compliance/tests/test_documentation_assets.py
+++ b/packages/compliance/tests/test_documentation_assets.py
@@ -112,7 +112,7 @@ def test_documentation_describes_current_product_boundaries() -> None:
     assert "does not fork the OpenHands agent loop" in product
     assert "process current directory" in architecture
     assert "one decision" in sessions
-    assert "One Heartwood process should write a given session at a time" in architecture
+    assert "Session mutation uses a separate interprocess lease for each session" in architecture
     assert "does not confer institutional approval" in security
 
 

--- a/packages/core-adapter/README.md
+++ b/packages/core-adapter/README.md
@@ -13,3 +13,5 @@ SPDX-License-Identifier: MIT
 Core harness orchestration for Heartwood sessions.
 
 This package defines the stable event-streaming execution facade used by the session service. The deterministic backend keeps tests and replay offline, while runtime packages can inject local or OpenHands-backed implementations behind the same assistant-message, tool-proposal, confirmation, and tool-execution event contract.
+
+The file-backed session service enforces one interprocess writer per session, persists idempotent command receipts, and commits each event with its audit record through a deterministic recovery journal.

--- a/packages/core-adapter/pyproject.toml
+++ b/packages/core-adapter/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Stanford University and the project authors" }]
 dependencies = [
+    "filelock==3.32.0",
     "heartwood-adapters",
     "heartwood-audit",
     "heartwood-model-policy",

--- a/packages/core-adapter/src/heartwood/core_adapter/__init__.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/__init__.py
@@ -17,17 +17,25 @@ from heartwood.core_adapter._facade import (
     ProposedToolCall,
     ToolExecution,
 )
-from heartwood.core_adapter._service import SessionResult, SessionService
-from heartwood.core_adapter._state import FileSessionStore, SessionStoreBoundaryError
+from heartwood.core_adapter._service import CommandConflictError, SessionResult, SessionService
+from heartwood.core_adapter._state import (
+    FileSessionStore,
+    SessionOwnershipError,
+    SessionRecoveryError,
+    SessionStoreBoundaryError,
+)
 
 __all__ = [
     "AgentBackend",
     "BackendEvent",
     "BackendEventKind",
+    "CommandConflictError",
     "DeterministicAgentBackend",
     "FileSessionStore",
     "LocalWorkspaceAgentBackend",
     "ProposedToolCall",
+    "SessionOwnershipError",
+    "SessionRecoveryError",
     "SessionResult",
     "SessionService",
     "SessionStoreBoundaryError",

--- a/packages/core-adapter/src/heartwood/core_adapter/__init__.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/__init__.py
@@ -22,6 +22,7 @@ from heartwood.core_adapter._state import (
     FileSessionStore,
     SessionOwnershipError,
     SessionRecoveryError,
+    SessionStorageCapabilityError,
     SessionStoreBoundaryError,
 )
 
@@ -38,6 +39,7 @@ __all__ = [
     "SessionRecoveryError",
     "SessionResult",
     "SessionService",
+    "SessionStorageCapabilityError",
     "SessionStoreBoundaryError",
     "ToolExecution",
     "__version__",

--- a/packages/core-adapter/src/heartwood/core_adapter/_service.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_service.py
@@ -236,15 +236,19 @@ class SessionService:
 
     def replay_events(self) -> tuple[SessionEvent, ...]:
         """Return events after verifying their one-to-one audit correspondence."""
-        if self.store.pending_commit_path.exists():
+        if not self.store.session_dir.exists():
+            return ()
+        while True:
+            with self.store.snapshot():
+                if not self.store.pending_commit_path.exists():
+                    audit_events = self.audit_log.read()
+                    self.audit_log.verify(audit_events)
+                    events = self.store.read_events()
+                    _verify_event_correspondence(audit_events, events)
+                    return events
             if not self.store.owns_writer:
                 self.store.acquire_writer()
             self.store.recover_pending_commit()
-        audit_events = self.audit_log.read()
-        self.audit_log.verify(audit_events)
-        events = self.store.read_events()
-        _verify_event_correspondence(audit_events, events)
-        return events
 
     def close(self) -> None:
         """Release backend resources."""

--- a/packages/core-adapter/src/heartwood/core_adapter/_service.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_service.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from threading import RLock
 from typing import Literal, cast
 
 from heartwood.adapters import PlatformAdapter
@@ -28,10 +29,16 @@ from heartwood.core_adapter._facade import (
     ProposedToolCall,
     ToolExecution,
 )
-from heartwood.core_adapter._state import FileSessionStore
+from heartwood.core_adapter._state import FileSessionStore, SessionRecoveryError
 from heartwood.model_policy import ModelPolicyEngine
 from heartwood.schemas import AuditEvent, ConfirmationRequest, JsonValue, PolicyProfile
-from heartwood.session import CommandKind, EventKind, SessionCommand, SessionEvent
+from heartwood.session import (
+    CommandKind,
+    EventKind,
+    SessionCommand,
+    SessionEvent,
+    compute_session_event_hash,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +46,11 @@ class SessionResult:
     """Events emitted while handling one command."""
 
     events: tuple[SessionEvent, ...]
+    replayed: bool = False
+
+
+class CommandConflictError(ValueError):
+    """Raised when a command identifier is reused with different content."""
 
 
 class SessionService:
@@ -62,7 +74,7 @@ class SessionService:
         self.policy = ModelPolicyEngine(self.policy_profile)
         self.env = os.environ if env is None else env
         self.clock: Callable[[], str] = _utc_now if clock is None else clock
-        self.backend.restore_pending(_pending_tool_calls(self.replay_events()))
+        self._command_lock = RLock()
 
     @classmethod
     def synthetic_default(
@@ -115,6 +127,48 @@ class SessionService:
                 f"store session {self.store.session_id}"
             )
             raise ValueError(msg)
+        with self._command_lock:
+            self.store.acquire_writer()
+            self.store.recover_pending_commit()
+            persisted = self.replay_events()
+            self.backend.restore_pending(_pending_tool_calls(persisted))
+            command_hash = _command_hash(command)
+            record = self.store.command_record(command.command_id)
+            if record is not None:
+                return _command_result_from_receipt(persisted, command, command_hash, record)
+            unresolved = self.store.unresolved_command_ids()
+            if unresolved:
+                raise SessionRecoveryError(
+                    f"session {self.store.session_id} has an interrupted command "
+                    f"({unresolved[0]}) and cannot accept more work; replay and verify the "
+                    "session, then continue in a new session"
+                )
+            duplicate = _legacy_duplicate_command_result(persisted, command, command_hash)
+            if duplicate is not None:
+                self.store.record_completed_legacy_command(
+                    command_id=command.command_id,
+                    command_hash=command_hash,
+                    first_sequence=duplicate.events[0].sequence,
+                    last_sequence=duplicate.events[-1].sequence,
+                )
+                return duplicate
+            first_sequence = self.store.next_sequence()
+            self.store.accept_command(
+                command_id=command.command_id,
+                command_hash=command_hash,
+                first_sequence=first_sequence,
+            )
+            result = self._handle_new_command(command)
+            self.store.complete_command(
+                command_id=command.command_id,
+                command_hash=command_hash,
+                first_sequence=first_sequence,
+                last_sequence=result.events[-1].sequence,
+            )
+            return result
+
+    def _handle_new_command(self, command: SessionCommand) -> SessionResult:
+        """Execute a command that has not previously been accepted."""
         command_kind = _kind_value(command.kind)
         events = [
             self._record_event(
@@ -122,6 +176,7 @@ class SessionService:
                 {
                     "actor_id": command.actor_id,
                     "command_id": command.command_id,
+                    "command_hash": _command_hash(command),
                     "command_kind": command_kind,
                 },
             )
@@ -181,6 +236,10 @@ class SessionService:
 
     def replay_events(self) -> tuple[SessionEvent, ...]:
         """Return events after verifying their one-to-one audit correspondence."""
+        if self.store.pending_commit_path.exists():
+            if not self.store.owns_writer:
+                self.store.acquire_writer()
+            self.store.recover_pending_commit()
         audit_events = self.audit_log.read()
         self.audit_log.verify(audit_events)
         events = self.store.read_events()
@@ -189,7 +248,10 @@ class SessionService:
 
     def close(self) -> None:
         """Release backend resources."""
-        self.backend.close()
+        try:
+            self.backend.close()
+        finally:
+            self.store.release_writer()
 
     def _handle_task(self, command: SessionCommand) -> tuple[SessionEvent, ...]:
         prompt_value = command.payload.get("prompt")
@@ -447,9 +509,9 @@ class SessionService:
         )
         audit_payload = {
             **_audit_payload(kind, payload),
-            "session_event_hash": _session_event_hash(event),
+            "session_event_hash": compute_session_event_hash(event),
         }
-        audit_event = self.audit_log.append(
+        audit_event = self.audit_log.prepare(
             session_id=self.store.session_id,
             event_type=kind.value,
             occurred_at=occurred_at,
@@ -460,7 +522,7 @@ class SessionService:
             or audit_event.previous_event_hash != previous_event_hash
         ):
             raise AuditIntegrityError("audit log changed during session event append")
-        self.store.append_event(event)
+        self.store.commit_event(event, audit_event)
         return event
 
 
@@ -469,17 +531,6 @@ def _audit_payload(kind: EventKind, payload: dict[str, JsonValue]) -> dict[str, 
     if kind != EventKind.ERROR_RECORDED:
         return payload
     return {key: "[scrubbed]" if key == "reason" else value for key, value in payload.items()}
-
-
-def _session_event_hash(event: SessionEvent) -> str:
-    """Bind the complete replay event to its content-minimized audit record."""
-    canonical = json.dumps(
-        event.model_dump(mode="json"),
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=True,
-    )
-    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
 
 
 def _verify_event_correspondence(
@@ -505,7 +556,7 @@ def _verify_event_correspondence(
                 f"session event does not match audit record at {event.event_id}"
             )
         recorded_hash = audit_event.payload.get("session_event_hash")
-        if recorded_hash != _session_event_hash(event):
+        if recorded_hash != compute_session_event_hash(event):
             raise AuditIntegrityError(f"session event hash mismatch at {event.event_id}")
 
 
@@ -529,6 +580,73 @@ def _utc_now() -> str:
 
 def _kind_value(kind: CommandKind | str) -> str:
     return kind.value if isinstance(kind, CommandKind) else kind
+
+
+def _command_hash(command: SessionCommand) -> str:
+    canonical = json.dumps(
+        command.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def _legacy_duplicate_command_result(
+    events: tuple[SessionEvent, ...],
+    command: SessionCommand,
+    expected_hash: str,
+) -> SessionResult | None:
+    for index, event in enumerate(events):
+        if event.kind != EventKind.COMMAND_RECEIVED:
+            continue
+        if event.payload.get("command_id") != command.command_id:
+            continue
+        if event.payload.get("command_hash") != expected_hash:
+            raise CommandConflictError(
+                f"command id {command.command_id} was already used with different content"
+            )
+        end = len(events)
+        for candidate_index in range(index + 1, len(events)):
+            if events[candidate_index].kind == EventKind.COMMAND_RECEIVED:
+                end = candidate_index
+                break
+        return SessionResult(events=events[index:end], replayed=True)
+    return None
+
+
+def _command_result_from_receipt(
+    events: tuple[SessionEvent, ...],
+    command: SessionCommand,
+    expected_hash: str,
+    record: dict[str, object],
+) -> SessionResult:
+    if record.get("command_hash") != expected_hash:
+        raise CommandConflictError(
+            f"command id {command.command_id} was already used with different content"
+        )
+    if record.get("state") != "completed":
+        raise SessionRecoveryError(
+            f"command {command.command_id} was interrupted after acceptance and will not be "
+            "executed again automatically; inspect session replay, then continue in a new session"
+        )
+    first_sequence = record.get("first_sequence")
+    last_sequence = record.get("last_sequence")
+    if not isinstance(first_sequence, int) or not isinstance(last_sequence, int):
+        raise SessionRecoveryError(f"completed command receipt is invalid for {command.command_id}")
+    selected = tuple(event for event in events if first_sequence <= event.sequence <= last_sequence)
+    expected_count = last_sequence - first_sequence + 1
+    if (
+        len(selected) != expected_count
+        or not selected
+        or selected[0].kind != EventKind.COMMAND_RECEIVED
+        or selected[0].payload.get("command_id") != command.command_id
+        or selected[0].payload.get("command_hash") != expected_hash
+    ):
+        raise SessionRecoveryError(
+            f"completed command events do not match the receipt for {command.command_id}"
+        )
+    return SessionResult(events=selected, replayed=True)
 
 
 def _pending_tool_calls(events: tuple[SessionEvent, ...]) -> tuple[ProposedToolCall, ...]:

--- a/packages/core-adapter/src/heartwood/core_adapter/_service.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_service.py
@@ -31,7 +31,7 @@ from heartwood.core_adapter._facade import (
 )
 from heartwood.core_adapter._state import FileSessionStore, SessionRecoveryError
 from heartwood.model_policy import ModelPolicyEngine
-from heartwood.schemas import AuditEvent, ConfirmationRequest, JsonValue, PolicyProfile
+from heartwood.schemas import ConfirmationRequest, JsonValue, PolicyProfile
 from heartwood.session import (
     CommandKind,
     EventKind,
@@ -236,19 +236,7 @@ class SessionService:
 
     def replay_events(self) -> tuple[SessionEvent, ...]:
         """Return events after verifying their one-to-one audit correspondence."""
-        if not self.store.session_dir.exists():
-            return ()
-        while True:
-            with self.store.snapshot():
-                if not self.store.pending_commit_path.exists():
-                    audit_events = self.audit_log.read()
-                    self.audit_log.verify(audit_events)
-                    events = self.store.read_events()
-                    _verify_event_correspondence(audit_events, events)
-                    return events
-            if not self.store.owns_writer:
-                self.store.acquire_writer()
-            self.store.recover_pending_commit()
+        return self.store.replay_events()
 
     def close(self) -> None:
         """Release backend resources."""
@@ -535,33 +523,6 @@ def _audit_payload(kind: EventKind, payload: dict[str, JsonValue]) -> dict[str, 
     if kind != EventKind.ERROR_RECORDED:
         return payload
     return {key: "[scrubbed]" if key == "reason" else value for key, value in payload.items()}
-
-
-def _verify_event_correspondence(
-    audit_events: tuple[AuditEvent, ...],
-    events: tuple[SessionEvent, ...],
-) -> None:
-    """Reject tampered, truncated, or partially persisted replay streams."""
-    if len(audit_events) != len(events):
-        raise AuditIntegrityError("session event and audit logs have different lengths")
-    for expected_sequence, (audit_event, event) in enumerate(
-        zip(audit_events, events, strict=True)
-    ):
-        if event.sequence != expected_sequence:
-            raise AuditIntegrityError(f"session event sequence gap at {event.event_id}")
-        if (
-            audit_event.sequence != event.sequence
-            or audit_event.session_id != event.session_id
-            or audit_event.event_type != _kind_value(event.kind)
-            or audit_event.occurred_at != event.occurred_at
-            or audit_event.previous_event_hash != event.previous_event_hash
-        ):
-            raise AuditIntegrityError(
-                f"session event does not match audit record at {event.event_id}"
-            )
-        recorded_hash = audit_event.payload.get("session_event_hash")
-        if recorded_hash != compute_session_event_hash(event):
-            raise AuditIntegrityError(f"session event hash mismatch at {event.event_id}")
 
 
 def _require_tool_call(event: BackendEvent) -> ProposedToolCall:

--- a/packages/core-adapter/src/heartwood/core_adapter/_state.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_state.py
@@ -119,12 +119,11 @@ class FileSessionStore:
         if lock is None:
             return
         try:
-            metadata = _read_private_json(self.writer_metadata_path)
-            if metadata.get("token") == self._writer_token:
-                self.writer_metadata_path.unlink(missing_ok=True)
-                _fsync_directory(self.session_dir)
-        except (OSError, ValueError):
-            pass
+            with suppress(OSError, ValueError):
+                metadata = _read_private_json(self.writer_metadata_path)
+                if metadata.get("token") == self._writer_token:
+                    self.writer_metadata_path.unlink(missing_ok=True)
+                    _fsync_directory(self.session_dir)
         finally:
             self._writer_lock = None
             self._writer_token = None

--- a/packages/core-adapter/src/heartwood/core_adapter/_state.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_state.py
@@ -8,15 +8,35 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
+import socket
+import tempfile
+import uuid
+from contextlib import suppress
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
-from heartwood.session import SessionEvent, validate_session_id
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
+from heartwood.audit import compute_event_hash
+from heartwood.schemas import AuditEvent
+from heartwood.session import SessionEvent, compute_session_event_hash, validate_session_id
 
 
 class SessionStoreBoundaryError(ValueError):
     """Raised when session state would escape the configured workspace root."""
+
+
+class SessionOwnershipError(RuntimeError):
+    """Raised when another process owns the session writer lease."""
+
+
+class SessionRecoveryError(ValueError):
+    """Raised when an interrupted session commit cannot be recovered safely."""
 
 
 class FileSessionStore:
@@ -41,15 +61,298 @@ class FileSessionStore:
         self.events_path = self.session_dir / "events.jsonl"
         self.audit_path = self.session_dir / "audit.jsonl"
         self.audit_export_path = self.session_dir / "audit-export.jsonl"
+        self.writer_lock_path = self.session_dir / ".writer.lock"
+        self.writer_metadata_path = self.session_dir / ".writer.json"
+        self.pending_commit_path = self.session_dir / ".pending-commit.json"
+        self.commands_dir = self.session_dir / ".commands"
         self._next_sequence: int | None = None
+        self._writer_lock: FileLock | None = None
+        self._writer_token: str | None = None
+        self.recovered_stale_writer = False
+
+    @property
+    def owns_writer(self) -> bool:
+        """Return whether this store currently owns the session writer lease."""
+        return self._writer_lock is not None
+
+    def acquire_writer(self) -> None:
+        """Acquire the exclusive session writer lease without waiting."""
+        if self._writer_lock is not None:
+            return
+        self._prepare_session_dir()
+        if self.writer_lock_path.is_symlink():
+            msg = f"session writer lock must not be a symbolic link: {self.session_id}"
+            raise SessionStoreBoundaryError(msg)
+        lock = FileLock(self.writer_lock_path, timeout=0, mode=0o600)
+        try:
+            lock.acquire()
+        except FileLockTimeout as error:
+            owner = _writer_owner_summary(self.writer_metadata_path)
+            raise SessionOwnershipError(
+                f"session {self.session_id} is active in another Heartwood process{owner}; "
+                "stop that process before continuing"
+            ) from error
+        try:
+            self.recovered_stale_writer = self.writer_metadata_path.exists()
+            self.writer_lock_path.chmod(0o600)
+            token = uuid.uuid4().hex
+            _write_private_json_atomic(
+                self.writer_metadata_path,
+                {
+                    "schema_version": "heartwood.session-writer.v1",
+                    "session_id": self.session_id,
+                    "pid": os.getpid(),
+                    "host": socket.gethostname(),
+                    "started_at": _utc_now(),
+                    "token": token,
+                },
+            )
+        except Exception:
+            lock.release()
+            raise
+        self._writer_lock = lock
+        self._writer_token = token
+
+    def release_writer(self) -> None:
+        """Release the session writer lease owned by this store."""
+        lock = self._writer_lock
+        if lock is None:
+            return
+        try:
+            metadata = _read_private_json(self.writer_metadata_path)
+            if metadata.get("token") == self._writer_token:
+                self.writer_metadata_path.unlink(missing_ok=True)
+                _fsync_directory(self.session_dir)
+        except (OSError, ValueError):
+            pass
+        finally:
+            self._writer_lock = None
+            self._writer_token = None
+            lock.release()
 
     def append_event(self, event: SessionEvent) -> None:
-        """Persist one session event envelope."""
+        """Persist one legacy session event envelope under the writer lease."""
+        if not self.owns_writer:
+            raise SessionOwnershipError("legacy session event appends require the writer lease")
         self._prepare_session_dir()
-        with _open_private_text(self.events_path, append=True) as file:
-            file.write(event.model_dump_json() + "\n")
+        _append_private_json_line(self.events_path, event.model_dump_json())
         if self._next_sequence is not None:
             self._next_sequence = max(self._next_sequence, event.sequence + 1)
+
+    def commit_event(self, event: SessionEvent, audit_event: AuditEvent) -> None:
+        """Commit one session event and its audit record through a recovery journal."""
+        if not self.owns_writer:
+            raise SessionOwnershipError("session event commits require the writer lease")
+        if event.session_id != self.session_id or audit_event.session_id != self.session_id:
+            raise SessionRecoveryError("pending commit session does not match the session store")
+        if event.sequence != audit_event.sequence:
+            raise SessionRecoveryError("pending event and audit sequences do not match")
+        _verify_pending_pair(event, audit_event)
+        self._prepare_session_dir()
+        if self.pending_commit_path.exists():
+            self.recover_pending_commit()
+        _write_private_json_atomic(
+            self.pending_commit_path,
+            {
+                "schema_version": "heartwood.session-commit.v1",
+                "session_event": event.model_dump(mode="json"),
+                "audit_event": audit_event.model_dump(mode="json"),
+            },
+        )
+        _append_private_json_line(self.audit_path, audit_event.model_dump_json())
+        _append_private_json_line(self.events_path, event.model_dump_json())
+        self.pending_commit_path.unlink()
+        _fsync_directory(self.session_dir)
+        self._next_sequence = event.sequence + 1
+
+    def recover_pending_commit(self) -> bool:
+        """Complete one interrupted paired event and audit append."""
+        if not self.pending_commit_path.exists():
+            return False
+        if not self.owns_writer:
+            raise SessionRecoveryError(
+                f"session {self.session_id} requires writer-owned commit recovery"
+            )
+        try:
+            payload = _read_private_json(self.pending_commit_path)
+            if payload.get("schema_version") != "heartwood.session-commit.v1":
+                raise SessionRecoveryError("unsupported pending session commit")
+            event = SessionEvent.model_validate(payload.get("session_event"))
+            audit_event = AuditEvent.model_validate(payload.get("audit_event"))
+        except (OSError, ValueError) as error:
+            if isinstance(error, SessionRecoveryError):
+                raise
+            raise SessionRecoveryError("pending session commit is malformed") from error
+        if (
+            event.session_id != self.session_id
+            or audit_event.session_id != self.session_id
+            or event.sequence != audit_event.sequence
+        ):
+            raise SessionRecoveryError("pending session commit identity does not match")
+        _verify_pending_pair(event, audit_event)
+
+        events, events_truncate_at = _read_recoverable_records(
+            self.events_path,
+            SessionEvent,
+        )
+        audit_events, audit_truncate_at = _read_recoverable_records(
+            self.audit_path,
+            AuditEvent,
+        )
+        _verify_recovery_prefix(audit_events, events)
+        sequence = event.sequence
+        _validate_pending_position("session event", events, event, sequence)
+        _validate_pending_position("audit", audit_events, audit_event, sequence)
+        if sequence:
+            previous_audit = audit_events[sequence - 1]
+            if (
+                previous_audit.event_hash != audit_event.previous_event_hash
+                or previous_audit.event_hash != event.previous_event_hash
+            ):
+                raise SessionRecoveryError("pending commit previous hash does not match")
+        elif audit_event.previous_event_hash is not None or event.previous_event_hash is not None:
+            raise SessionRecoveryError("first pending commit must not reference a previous hash")
+        if audit_truncate_at is not None:
+            _truncate_private_file(self.audit_path, audit_truncate_at)
+        if events_truncate_at is not None:
+            _truncate_private_file(self.events_path, events_truncate_at)
+        if len(audit_events) == sequence:
+            _append_private_json_line(self.audit_path, audit_event.model_dump_json())
+        if len(events) == sequence:
+            _append_private_json_line(self.events_path, event.model_dump_json())
+        self.pending_commit_path.unlink()
+        _fsync_directory(self.session_dir)
+        self._next_sequence = sequence + 1
+        return True
+
+    def command_record(self, command_id: str) -> dict[str, Any] | None:
+        """Return one durable command receipt."""
+        path = self._command_path(command_id)
+        if not path.exists():
+            return None
+        try:
+            payload = _read_private_json(path)
+        except (OSError, ValueError) as error:
+            raise SessionRecoveryError(f"command receipt is malformed for {command_id}") from error
+        _validate_command_record(payload, command_id)
+        if payload.get("session_id") != self.session_id:
+            raise SessionRecoveryError(
+                f"command receipt belongs to another session for {command_id}"
+            )
+        return payload
+
+    def unresolved_command_ids(self) -> tuple[str, ...]:
+        """Return accepted command identifiers that have no completion receipt."""
+        if self.commands_dir.is_symlink():
+            raise SessionStoreBoundaryError(
+                f"session command receipt path must not be a symbolic link: {self.session_id}"
+            )
+        if not self.commands_dir.exists():
+            return ()
+        if not self.commands_dir.is_dir():
+            raise SessionStoreBoundaryError(
+                f"session command receipt path must be a directory: {self.session_id}"
+            )
+        unresolved: list[tuple[int, str]] = []
+        for path in self.commands_dir.glob("*.json"):
+            try:
+                payload = _read_private_json(path)
+                command_id = payload.get("command_id")
+                if not isinstance(command_id, str):
+                    raise SessionRecoveryError(f"invalid command receipt in {path}")
+                _validate_command_record(payload, command_id)
+            except (OSError, ValueError) as error:
+                if isinstance(error, SessionRecoveryError):
+                    raise
+                raise SessionRecoveryError(f"command receipt is malformed in {path}") from error
+            if payload.get("session_id") != self.session_id:
+                raise SessionRecoveryError(f"command receipt belongs to another session in {path}")
+            if payload["state"] == "accepted":
+                unresolved.append((payload["first_sequence"], command_id))
+        return tuple(command_id for _, command_id in sorted(unresolved))
+
+    def accept_command(
+        self,
+        *,
+        command_id: str,
+        command_hash: str,
+        first_sequence: int,
+    ) -> None:
+        """Persist command intent before model or tool execution."""
+        if not self.owns_writer:
+            raise SessionOwnershipError("command acceptance requires the writer lease")
+        if self.command_record(command_id) is not None:
+            raise SessionRecoveryError(f"command receipt already exists for {command_id}")
+        self._prepare_commands_dir()
+        _write_private_json_atomic(
+            self._command_path(command_id),
+            {
+                "schema_version": "heartwood.session-command-receipt.v1",
+                "session_id": self.session_id,
+                "command_id": command_id,
+                "command_hash": command_hash,
+                "state": "accepted",
+                "first_sequence": first_sequence,
+                "last_sequence": None,
+            },
+        )
+
+    def complete_command(
+        self,
+        *,
+        command_id: str,
+        command_hash: str,
+        first_sequence: int,
+        last_sequence: int,
+    ) -> None:
+        """Mark one accepted command complete after all events are durable."""
+        if not self.owns_writer:
+            raise SessionOwnershipError("command completion requires the writer lease")
+        if last_sequence < first_sequence:
+            raise SessionRecoveryError("completed command sequence is invalid")
+        record = self.command_record(command_id)
+        if (
+            record is None
+            or record.get("command_hash") != command_hash
+            or record.get("state") != "accepted"
+            or record.get("first_sequence") != first_sequence
+        ):
+            raise SessionRecoveryError(f"accepted command receipt changed for {command_id}")
+        _write_private_json_atomic(
+            self._command_path(command_id),
+            {
+                **record,
+                "state": "completed",
+                "last_sequence": last_sequence,
+            },
+        )
+
+    def record_completed_legacy_command(
+        self,
+        *,
+        command_id: str,
+        command_hash: str,
+        first_sequence: int,
+        last_sequence: int,
+    ) -> None:
+        """Create a completed receipt for an event-only command."""
+        if not self.owns_writer:
+            raise SessionOwnershipError("command migration requires the writer lease")
+        if self.command_record(command_id) is not None:
+            return
+        self._prepare_commands_dir()
+        _write_private_json_atomic(
+            self._command_path(command_id),
+            {
+                "schema_version": "heartwood.session-command-receipt.v1",
+                "session_id": self.session_id,
+                "command_id": command_id,
+                "command_hash": command_hash,
+                "state": "completed",
+                "first_sequence": first_sequence,
+                "last_sequence": last_sequence,
+            },
+        )
 
     def read_events(self) -> tuple[SessionEvent, ...]:
         """Read persisted session events."""
@@ -68,9 +371,10 @@ class FileSessionStore:
 
     def write_audit_export(self, content: str) -> None:
         """Write the scrubbed audit export as an owner-only file."""
+        if not self.owns_writer:
+            raise SessionOwnershipError("audit export writes require the writer lease")
         self._prepare_session_dir()
-        with _open_private_text(self.audit_export_path, append=False) as file:
-            file.write(content)
+        _write_private_text_atomic(self.audit_export_path, content)
 
     def read_audit_export(self) -> str:
         """Read the generated audit export without following symbolic links."""
@@ -78,19 +382,231 @@ class FileSessionStore:
             return file.read()
 
     def _prepare_session_dir(self) -> None:
+        if self.session_dir.is_symlink():
+            raise SessionStoreBoundaryError(
+                f"session path must not be a symbolic link: {self.session_id}"
+            )
         self.session_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.session_dir.chmod(0o700)
 
+    def _prepare_commands_dir(self) -> None:
+        if self.commands_dir.is_symlink():
+            raise SessionStoreBoundaryError(
+                f"session command receipt path must not be a symbolic link: {self.session_id}"
+            )
+        self.commands_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if not self.commands_dir.is_dir():
+            raise SessionStoreBoundaryError(
+                f"session command receipt path must be a directory: {self.session_id}"
+            )
+        self.commands_dir.chmod(0o700)
 
-def _open_private_text(path: Path, *, append: bool) -> TextIO:
-    flags = os.O_CREAT | os.O_WRONLY | (os.O_APPEND if append else os.O_TRUNC)
-    flags |= getattr(os, "O_NOFOLLOW", 0)
-    descriptor = os.open(path, flags, 0o600)
-    os.fchmod(descriptor, 0o600)
-    return os.fdopen(descriptor, "a" if append else "w", encoding="utf-8")
+    def _command_path(self, command_id: str) -> Path:
+        if self.commands_dir.is_symlink():
+            raise SessionStoreBoundaryError(
+                f"session command receipt path must not be a symbolic link: {self.session_id}"
+            )
+        digest = hashlib.sha256(command_id.encode("utf-8")).hexdigest()
+        return self.commands_dir / f"{digest}.json"
 
 
 def _open_private_read(path: Path) -> TextIO:
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
     return os.fdopen(descriptor, encoding="utf-8")
+
+
+def _append_private_json_line(path: Path, content: str) -> None:
+    data = (content + "\n").encode("utf-8")
+    flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        remaining = memoryview(data)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:  # pragma: no cover - operating-system invariant
+                raise OSError("session append made no progress")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_private_text_atomic(path: Path, content: str) -> None:
+    _write_private_bytes_atomic(path, content.encode("utf-8"))
+
+
+def _write_private_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    content = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+    _write_private_bytes_atomic(path, content.encode("utf-8"))
+
+
+def _write_private_bytes_atomic(path: Path, content: bytes) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}-", dir=path.parent)
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        remaining = memoryview(content)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:  # pragma: no cover - operating-system invariant
+                raise OSError("atomic session write made no progress")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        temporary_path.replace(path)
+        path.chmod(0o600)
+        _fsync_directory(path.parent)
+    except Exception:
+        if descriptor >= 0:
+            with suppress(OSError):
+                os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def _read_private_json(path: Path) -> dict[str, Any]:
+    with _open_private_read(path) as file:
+        payload = json.load(file)
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected an object in {path}")
+    return payload
+
+
+def _read_recoverable_records[Record: (SessionEvent, AuditEvent)](
+    path: Path,
+    record_type: type[Record],
+) -> tuple[tuple[Record, ...], int | None]:
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+    except FileNotFoundError:
+        return (), None
+    try:
+        content = bytearray()
+        while chunk := os.read(descriptor, 64 * 1024):
+            content.extend(chunk)
+    finally:
+        os.close(descriptor)
+    truncate_at: int | None = None
+    if content and not content.endswith(b"\n"):
+        boundary = content.rfind(b"\n") + 1
+        truncate_at = boundary
+        content = content[:boundary]
+    try:
+        records = tuple(
+            record_type.model_validate_json(line)
+            for line in content.decode("utf-8").splitlines()
+            if line
+        )
+    except (UnicodeDecodeError, ValueError) as error:
+        raise SessionRecoveryError(f"unable to recover session records in {path}") from error
+    return records, truncate_at
+
+
+def _truncate_private_file(path: Path, size: int) -> None:
+    flags = os.O_WRONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.ftruncate(descriptor, size)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _validate_pending_position[Record](
+    label: str,
+    records: tuple[Record, ...],
+    pending: Record,
+    sequence: int,
+) -> None:
+    if len(records) == sequence:
+        return
+    if len(records) == sequence + 1 and records[-1] == pending:
+        return
+    raise SessionRecoveryError(f"{label} log does not match the pending commit")
+
+
+def _verify_recovery_prefix(
+    audit_events: tuple[AuditEvent, ...],
+    events: tuple[SessionEvent, ...],
+) -> None:
+    previous_hash: str | None = None
+    for expected_sequence, audit_event in enumerate(audit_events):
+        if (
+            audit_event.sequence != expected_sequence
+            or audit_event.previous_event_hash != previous_hash
+            or audit_event.event_hash != compute_event_hash(audit_event)
+        ):
+            raise SessionRecoveryError("existing audit prefix is invalid")
+        previous_hash = audit_event.event_hash
+    for expected_sequence, event in enumerate(events):
+        if event.sequence != expected_sequence:
+            raise SessionRecoveryError("existing session event prefix is invalid")
+    for audit_event, event in zip(audit_events, events, strict=False):
+        _verify_pending_pair(event, audit_event)
+
+
+def _verify_pending_pair(event: SessionEvent, audit_event: AuditEvent) -> None:
+    if audit_event.event_hash != compute_event_hash(audit_event):
+        raise SessionRecoveryError("pending audit event hash does not match")
+    if (
+        audit_event.sequence != event.sequence
+        or audit_event.session_id != event.session_id
+        or audit_event.event_type != str(event.kind)
+        or audit_event.occurred_at != event.occurred_at
+        or audit_event.previous_event_hash != event.previous_event_hash
+        or audit_event.payload.get("session_event_hash") != compute_session_event_hash(event)
+    ):
+        raise SessionRecoveryError("pending event and audit record do not correspond")
+
+
+def _validate_command_record(payload: dict[str, Any], command_id: str) -> None:
+    if (
+        payload.get("schema_version") != "heartwood.session-command-receipt.v1"
+        or payload.get("command_id") != command_id
+        or not isinstance(payload.get("session_id"), str)
+        or not isinstance(payload.get("command_hash"), str)
+        or payload.get("state") not in {"accepted", "completed"}
+        or not isinstance(payload.get("first_sequence"), int)
+        or payload["first_sequence"] < 0
+    ):
+        raise SessionRecoveryError(f"invalid command receipt for {command_id}")
+    last_sequence = payload.get("last_sequence")
+    if payload["state"] == "completed" and (
+        not isinstance(last_sequence, int) or last_sequence < payload["first_sequence"]
+    ):
+        raise SessionRecoveryError(f"completed command receipt is incomplete for {command_id}")
+    if payload["state"] == "accepted" and last_sequence is not None:
+        raise SessionRecoveryError(f"accepted command receipt is inconsistent for {command_id}")
+
+
+def _writer_owner_summary(path: Path) -> str:
+    try:
+        payload = _read_private_json(path)
+    except (OSError, ValueError):
+        return ""
+    pid = payload.get("pid")
+    host = payload.get("host")
+    if isinstance(pid, int) and isinstance(host, str):
+        return f" (pid {pid} on {host})"
+    return ""
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/packages/core-adapter/src/heartwood/core_adapter/_state.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_state.py
@@ -14,7 +14,8 @@ import os
 import socket
 import tempfile
 import uuid
-from contextlib import suppress
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TextIO
@@ -63,10 +64,12 @@ class FileSessionStore:
         self.audit_export_path = self.session_dir / "audit-export.jsonl"
         self.writer_lock_path = self.session_dir / ".writer.lock"
         self.writer_metadata_path = self.session_dir / ".writer.json"
+        self.snapshot_lock_path = self.session_dir / ".snapshot.lock"
         self.pending_commit_path = self.session_dir / ".pending-commit.json"
         self.commands_dir = self.session_dir / ".commands"
         self._next_sequence: int | None = None
         self._writer_lock: FileLock | None = None
+        self._snapshot_lock = FileLock(self.snapshot_lock_path, timeout=10, mode=0o600)
         self._writer_token: str | None = None
         self.recovered_stale_writer = False
 
@@ -129,6 +132,23 @@ class FileSessionStore:
             self._writer_token = None
             lock.release()
 
+    @contextmanager
+    def snapshot(self) -> Iterator[None]:
+        """Hold a stable paired view of the session event and audit logs."""
+        self._prepare_session_dir()
+        if self.snapshot_lock_path.is_symlink():
+            raise SessionStoreBoundaryError(
+                f"session snapshot lock must not be a symbolic link: {self.session_id}"
+            )
+        try:
+            with self._snapshot_lock:
+                self.snapshot_lock_path.chmod(0o600)
+                yield
+        except FileLockTimeout as error:
+            raise SessionRecoveryError(
+                f"session {self.session_id} did not provide a stable persistence snapshot"
+            ) from error
+
     def append_event(self, event: SessionEvent) -> None:
         """Persist one legacy session event envelope under the writer lease."""
         if not self.owns_writer:
@@ -147,31 +167,35 @@ class FileSessionStore:
         if event.sequence != audit_event.sequence:
             raise SessionRecoveryError("pending event and audit sequences do not match")
         _verify_pending_pair(event, audit_event)
-        self._prepare_session_dir()
-        if self.pending_commit_path.exists():
-            self.recover_pending_commit()
-        _write_private_json_atomic(
-            self.pending_commit_path,
-            {
-                "schema_version": "heartwood.session-commit.v1",
-                "session_event": event.model_dump(mode="json"),
-                "audit_event": audit_event.model_dump(mode="json"),
-            },
-        )
-        _append_private_json_line(self.audit_path, audit_event.model_dump_json())
-        _append_private_json_line(self.events_path, event.model_dump_json())
-        self.pending_commit_path.unlink()
-        _fsync_directory(self.session_dir)
-        self._next_sequence = event.sequence + 1
+        with self.snapshot():
+            if self.pending_commit_path.exists():
+                self._recover_pending_commit_locked()
+            _write_private_json_atomic(
+                self.pending_commit_path,
+                {
+                    "schema_version": "heartwood.session-commit.v1",
+                    "session_event": event.model_dump(mode="json"),
+                    "audit_event": audit_event.model_dump(mode="json"),
+                },
+            )
+            _append_private_json_line(self.audit_path, audit_event.model_dump_json())
+            _append_private_json_line(self.events_path, event.model_dump_json())
+            self.pending_commit_path.unlink()
+            _fsync_directory(self.session_dir)
+            self._next_sequence = event.sequence + 1
 
     def recover_pending_commit(self) -> bool:
         """Complete one interrupted paired event and audit append."""
-        if not self.pending_commit_path.exists():
-            return False
         if not self.owns_writer:
             raise SessionRecoveryError(
                 f"session {self.session_id} requires writer-owned commit recovery"
             )
+        with self.snapshot():
+            return self._recover_pending_commit_locked()
+
+    def _recover_pending_commit_locked(self) -> bool:
+        if not self.pending_commit_path.exists():
+            return False
         try:
             payload = _read_private_json(self.pending_commit_path)
             if payload.get("schema_version") != "heartwood.session-commit.v1":

--- a/packages/core-adapter/src/heartwood/core_adapter/_state.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_state.py
@@ -69,7 +69,7 @@ class FileSessionStore:
         self.commands_dir = self.session_dir / ".commands"
         self._next_sequence: int | None = None
         self._writer_lock: FileLock | None = None
-        self._snapshot_lock = FileLock(self.snapshot_lock_path, timeout=10, mode=0o600)
+        self._snapshot_lock = FileLock(self.snapshot_lock_path, mode=0o600)
         self._writer_token: str | None = None
         self.recovered_stale_writer = False
 
@@ -140,14 +140,9 @@ class FileSessionStore:
             raise SessionStoreBoundaryError(
                 f"session snapshot lock must not be a symbolic link: {self.session_id}"
             )
-        try:
-            with self._snapshot_lock:
-                self.snapshot_lock_path.chmod(0o600)
-                yield
-        except FileLockTimeout as error:
-            raise SessionRecoveryError(
-                f"session {self.session_id} did not provide a stable persistence snapshot"
-            ) from error
+        with self._snapshot_lock.acquire(timeout=-1):
+            self.snapshot_lock_path.chmod(0o600)
+            yield
 
     def append_event(self, event: SessionEvent) -> None:
         """Persist one legacy session event envelope under the writer lease."""

--- a/packages/core-adapter/src/heartwood/core_adapter/_state.py
+++ b/packages/core-adapter/src/heartwood/core_adapter/_state.py
@@ -23,7 +23,7 @@ from typing import Any, TextIO
 from filelock import FileLock
 from filelock import Timeout as FileLockTimeout
 
-from heartwood.audit import compute_event_hash
+from heartwood.audit import AuditIntegrityError, AuditLog, compute_event_hash
 from heartwood.schemas import AuditEvent
 from heartwood.session import SessionEvent, compute_session_event_hash, validate_session_id
 
@@ -38,6 +38,10 @@ class SessionOwnershipError(RuntimeError):
 
 class SessionRecoveryError(ValueError):
     """Raised when an interrupted session commit cannot be recovered safely."""
+
+
+class SessionStorageCapabilityError(SessionRecoveryError):
+    """Raised when session storage cannot provide required durability semantics."""
 
 
 class FileSessionStore:
@@ -69,7 +73,11 @@ class FileSessionStore:
         self.commands_dir = self.session_dir / ".commands"
         self._next_sequence: int | None = None
         self._writer_lock: FileLock | None = None
-        self._snapshot_lock = FileLock(self.snapshot_lock_path, mode=0o600)
+        self._snapshot_lock = FileLock(
+            self.snapshot_lock_path,
+            mode=0o600,
+            fallback_to_soft=False,
+        )
         self._writer_token: str | None = None
         self.recovered_stale_writer = False
 
@@ -86,7 +94,12 @@ class FileSessionStore:
         if self.writer_lock_path.is_symlink():
             msg = f"session writer lock must not be a symbolic link: {self.session_id}"
             raise SessionStoreBoundaryError(msg)
-        lock = FileLock(self.writer_lock_path, timeout=0, mode=0o600)
+        lock = FileLock(
+            self.writer_lock_path,
+            timeout=0,
+            mode=0o600,
+            fallback_to_soft=False,
+        )
         try:
             lock.acquire()
         except FileLockTimeout as error:
@@ -94,6 +107,10 @@ class FileSessionStore:
             raise SessionOwnershipError(
                 f"session {self.session_id} is active in another Heartwood process{owner}; "
                 "stop that process before continuing"
+            ) from error
+        except OSError as error:
+            raise SessionStorageCapabilityError(
+                f"session storage does not support required process locks: {self.session_id}"
             ) from error
         try:
             self.recovered_stale_writer = self.writer_metadata_path.exists()
@@ -140,18 +157,15 @@ class FileSessionStore:
             raise SessionStoreBoundaryError(
                 f"session snapshot lock must not be a symbolic link: {self.session_id}"
             )
-        with self._snapshot_lock.acquire(timeout=-1):
+        try:
+            lock = self._snapshot_lock.acquire(timeout=-1)
+        except OSError as error:
+            raise SessionStorageCapabilityError(
+                f"session storage does not support required process locks: {self.session_id}"
+            ) from error
+        with lock:
             self.snapshot_lock_path.chmod(0o600)
             yield
-
-    def append_event(self, event: SessionEvent) -> None:
-        """Persist one legacy session event envelope under the writer lease."""
-        if not self.owns_writer:
-            raise SessionOwnershipError("legacy session event appends require the writer lease")
-        self._prepare_session_dir()
-        _append_private_json_line(self.events_path, event.model_dump_json())
-        if self._next_sequence is not None:
-            self._next_sequence = max(self._next_sequence, event.sequence + 1)
 
     def commit_event(self, event: SessionEvent, audit_event: AuditEvent) -> None:
         """Commit one session event and its audit record through a recovery journal."""
@@ -381,6 +395,36 @@ class FileSessionStore:
             return ()
         return tuple(SessionEvent.model_validate_json(line) for line in lines if line)
 
+    def replay_events(self) -> tuple[SessionEvent, ...]:
+        """Recover if needed, then return one verified event-and-audit snapshot."""
+        if not self.session_dir.exists():
+            return ()
+        acquired_writer = False
+        try:
+            while True:
+                with self.snapshot():
+                    if not self.pending_commit_path.exists():
+                        try:
+                            audit_log = AuditLog(self.audit_path)
+                            audit_events = audit_log.read()
+                            audit_log.verify(audit_events)
+                            events = self.read_events()
+                        except (OSError, UnicodeDecodeError, ValueError) as error:
+                            if isinstance(error, AuditIntegrityError):
+                                raise
+                            raise SessionRecoveryError(
+                                f"session {self.session_id} records are malformed"
+                            ) from error
+                        _verify_event_correspondence(audit_events, events)
+                        return events
+                if not self.owns_writer:
+                    self.acquire_writer()
+                    acquired_writer = True
+                self.recover_pending_commit()
+        finally:
+            if acquired_writer:
+                self.release_writer()
+
     def next_sequence(self) -> int:
         """Return the next sequence without advancing until the event is durable."""
         if self._next_sequence is None:
@@ -580,6 +624,33 @@ def _verify_pending_pair(event: SessionEvent, audit_event: AuditEvent) -> None:
         or audit_event.payload.get("session_event_hash") != compute_session_event_hash(event)
     ):
         raise SessionRecoveryError("pending event and audit record do not correspond")
+
+
+def _verify_event_correspondence(
+    audit_events: tuple[AuditEvent, ...],
+    events: tuple[SessionEvent, ...],
+) -> None:
+    """Reject tampered, truncated, or partially persisted replay streams."""
+    if len(audit_events) != len(events):
+        raise AuditIntegrityError("session event and audit logs have different lengths")
+    for expected_sequence, (audit_event, event) in enumerate(
+        zip(audit_events, events, strict=True)
+    ):
+        if event.sequence != expected_sequence:
+            raise AuditIntegrityError(f"session event sequence gap at {event.event_id}")
+        if (
+            audit_event.sequence != event.sequence
+            or audit_event.session_id != event.session_id
+            or audit_event.event_type != str(event.kind)
+            or audit_event.occurred_at != event.occurred_at
+            or audit_event.previous_event_hash != event.previous_event_hash
+        ):
+            raise AuditIntegrityError(
+                f"session event does not match audit record at {event.event_id}"
+            )
+        recorded_hash = audit_event.payload.get("session_event_hash")
+        if recorded_hash != compute_session_event_hash(event):
+            raise AuditIntegrityError(f"session event hash mismatch at {event.event_id}")
 
 
 def _validate_command_record(payload: dict[str, Any], command_id: str) -> None:

--- a/packages/core-adapter/tests/test_session_service.py
+++ b/packages/core-adapter/tests/test_session_service.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import stat
 import subprocess
@@ -29,6 +30,7 @@ from heartwood.core_adapter import (
     SessionOwnershipError,
     SessionRecoveryError,
     SessionService,
+    SessionStorageCapabilityError,
     SessionStoreBoundaryError,
 )
 from heartwood.schemas import AuditEvent, PolicyProfile
@@ -731,8 +733,6 @@ def test_session_store_mutations_require_writer_ownership(tmp_path: Path) -> Non
     store.pending_commit_path.write_text("{}\n", encoding="utf-8")
 
     with pytest.raises(SessionOwnershipError):
-        store.append_event(event)
-    with pytest.raises(SessionOwnershipError):
         store.commit_event(event, audit_event)
     with pytest.raises(SessionRecoveryError, match="writer-owned"):
         store.recover_pending_commit()
@@ -806,6 +806,28 @@ def test_writer_setup_failure_releases_operating_system_lock(
     second.acquire_writer()
 
     assert second.owns_writer
+
+
+def test_session_locks_fail_closed_when_native_locking_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def native_lock_unavailable(_descriptor: int) -> bool:
+        raise OSError(errno.ENOSYS, "synthetic unsupported filesystem")
+
+    monkeypatch.setattr("filelock._unix._lock_fd_nonblocking", native_lock_unavailable)
+
+    writer_store = FileSessionStore(tmp_path / "writer", "session-synthetic-001")
+    with pytest.raises(SessionStorageCapabilityError, match="required process locks"):
+        writer_store.acquire_writer()
+    assert not writer_store.owns_writer
+
+    snapshot_store = FileSessionStore(tmp_path / "snapshot", "session-synthetic-001")
+    with (
+        pytest.raises(SessionStorageCapabilityError, match="required process locks"),
+        snapshot_store.snapshot(),
+    ):
+        pytest.fail("snapshot unexpectedly acquired a soft lock")
 
 
 def test_command_receipt_state_machine_rejects_invalid_transitions(tmp_path: Path) -> None:

--- a/packages/core-adapter/tests/test_session_service.py
+++ b/packages/core-adapter/tests/test_session_service.py
@@ -8,23 +8,37 @@ from __future__ import annotations
 
 import json
 import stat
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
 
-from heartwood.audit import AuditIntegrityError
+import heartwood.core_adapter._state as session_state
+from heartwood.audit import AuditIntegrityError, compute_event_hash
 from heartwood.core_adapter import (
     BackendEvent,
     BackendEventKind,
+    CommandConflictError,
     DeterministicAgentBackend,
     FileSessionStore,
     LocalWorkspaceAgentBackend,
     ProposedToolCall,
+    SessionOwnershipError,
+    SessionRecoveryError,
     SessionService,
     SessionStoreBoundaryError,
 )
-from heartwood.schemas import PolicyProfile
-from heartwood.session import CommandKind, EventKind, JsonValue, SessionCommand
+from heartwood.schemas import AuditEvent, PolicyProfile
+from heartwood.session import (
+    CommandKind,
+    EventKind,
+    JsonValue,
+    SessionCommand,
+    SessionEvent,
+    compute_session_event_hash,
+)
 
 
 def test_pause_persists_replayable_events(tmp_path: Path) -> None:
@@ -37,6 +51,461 @@ def test_pause_persists_replayable_events(tmp_path: Path) -> None:
         EventKind.SESSION_PAUSED.value,
     ]
     assert service.replay_events() == result.events
+
+
+def test_completed_command_retry_returns_exact_events_without_backend_reexecution(
+    tmp_path: Path,
+) -> None:
+    backend = _RecordingBackend(
+        endpoint="https://model.local.invalid/v1/chat/completions",
+        response=(BackendEvent(kind=BackendEventKind.AGENT_MESSAGE, message="done"),),
+    )
+    service = SessionService.local_default(
+        tmp_path,
+        backend=backend,
+        clock=lambda: "2026-01-01T00:00:00Z",
+    )
+    command = _command(CommandKind.CHAT, prompt="summarize").model_copy(
+        update={"session_id": "session-main"}
+    )
+
+    first = service.handle(command)
+    retried = service.handle(command)
+
+    assert retried.replayed
+    assert retried.events == first.events
+    assert backend.prompts == ["summarize"]
+    assert service.replay_events() == first.events
+
+
+def test_completed_command_retry_survives_gateway_restart(tmp_path: Path) -> None:
+    first_backend = _RecordingBackend(
+        endpoint="https://model.local.invalid/v1/chat/completions",
+        response=(BackendEvent(kind=BackendEventKind.AGENT_MESSAGE, message="done"),),
+    )
+    first_service = SessionService.local_default(
+        tmp_path,
+        backend=first_backend,
+        clock=lambda: "2026-01-01T00:00:00Z",
+    )
+    command = _command(CommandKind.CHAT, prompt="summarize").model_copy(
+        update={"session_id": "session-main"}
+    )
+    first = first_service.handle(command)
+    first_service.close()
+    restarted_backend = _RecordingBackend(
+        endpoint="https://model.local.invalid/v1/chat/completions"
+    )
+    restarted_service = SessionService.local_default(
+        tmp_path,
+        backend=restarted_backend,
+        clock=lambda: "2026-01-01T00:00:00Z",
+    )
+
+    retried = restarted_service.handle(command)
+
+    assert retried.events == first.events
+    assert retried.replayed
+    assert restarted_backend.prompts == []
+    assert restarted_service.replay_events() == first.events
+
+
+def test_command_identifier_reuse_with_different_content_is_rejected(tmp_path: Path) -> None:
+    service = SessionService.synthetic_default(tmp_path)
+    service.handle(_command(CommandKind.PAUSE))
+
+    with pytest.raises(CommandConflictError, match="different content"):
+        service.handle(
+            _command(CommandKind.PAUSE).model_copy(update={"created_at": "2026-01-01T00:00:01Z"})
+        )
+
+    assert len(service.replay_events()) == 2
+
+
+def test_retried_approval_does_not_repeat_backend_tool_resolution(tmp_path: Path) -> None:
+    tool_call = ProposedToolCall(
+        tool_call_id="session-main-action",
+        tool_name="file_editor",
+        risk="medium",
+        summary="write one file",
+    )
+    backend = _RecordingBackend(
+        endpoint="https://model.local.invalid/v1/chat/completions",
+        response=(
+            BackendEvent(kind=BackendEventKind.TOOL_CALL_PROPOSED, tool_call=tool_call),
+            BackendEvent(kind=BackendEventKind.CONFIRMATION_REQUESTED, tool_call=tool_call),
+        ),
+    )
+    service = SessionService.local_default(
+        tmp_path,
+        backend=backend,
+        clock=lambda: "2026-01-01T00:00:00Z",
+    )
+    service.handle(
+        _command(CommandKind.CHAT, prompt="write").model_copy(update={"session_id": "session-main"})
+    )
+    approval = _command(
+        CommandKind.APPROVE,
+        target_type="tool-call",
+        target_id=tool_call.tool_call_id,
+    ).model_copy(update={"session_id": "session-main"})
+
+    first = service.handle(approval)
+    retried = service.handle(approval)
+
+    assert retried.replayed
+    assert retried.events == first.events
+    assert backend.resolutions == [(tool_call.tool_call_id, True)]
+
+
+def test_second_writer_cannot_mutate_until_owner_closes(tmp_path: Path) -> None:
+    first = SessionService.synthetic_default(tmp_path)
+    second = SessionService.synthetic_default(tmp_path)
+    first.handle(_command(CommandKind.PAUSE))
+
+    with pytest.raises(SessionOwnershipError, match="active in another Heartwood process"):
+        second.handle(_command(CommandKind.RESUME))
+
+    first.close()
+    result = second.handle(_command(CommandKind.RESUME))
+    assert result.events[-1].kind == EventKind.SESSION_RESUMED.value
+
+
+def test_writer_lease_excludes_another_process(tmp_path: Path) -> None:
+    owner = SessionService.synthetic_default(tmp_path)
+    owner.handle(_command(CommandKind.PAUSE))
+    child_script = """
+import sys
+from pathlib import Path
+from heartwood.core_adapter import SessionOwnershipError, SessionService
+from heartwood.session import CommandKind, SessionCommand
+
+service = SessionService.synthetic_default(Path(sys.argv[1]))
+command = SessionCommand(
+    command_id="child-resume",
+    session_id="session-synthetic-001",
+    kind=CommandKind.RESUME,
+    actor_id="child",
+    created_at="2026-01-01T00:00:00Z",
+)
+try:
+    service.handle(command)
+except SessionOwnershipError:
+    raise SystemExit(23)
+service.close()
+"""
+
+    blocked = subprocess.run(
+        [sys.executable, "-c", child_script, str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    owner.close()
+    handed_off = subprocess.run(
+        [sys.executable, "-c", child_script, str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert blocked.returncode == 23, blocked.stderr
+    assert handed_off.returncode == 0, handed_off.stderr
+
+
+def test_distinct_sessions_can_mutate_independently(tmp_path: Path) -> None:
+    first = SessionService.synthetic_default(tmp_path, session_id="session-one")
+    second = SessionService.synthetic_default(tmp_path, session_id="session-two")
+    first_command = _command(CommandKind.PAUSE).model_copy(
+        update={"command_id": "pause-one", "session_id": "session-one"}
+    )
+    second_command = _command(CommandKind.PAUSE).model_copy(
+        update={"command_id": "pause-two", "session_id": "session-two"}
+    )
+
+    first_result = first.handle(first_command)
+    second_result = second.handle(second_command)
+
+    assert first_result.events[-1].kind == EventKind.SESSION_PAUSED.value
+    assert second_result.events[-1].kind == EventKind.SESSION_PAUSED.value
+
+
+def test_stale_writer_metadata_is_detected_and_reclaimed(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.session_dir.mkdir(mode=0o700, parents=True)
+    store.writer_metadata_path.write_text(
+        '{"host":"stale-host","pid":123,"token":"stale"}\n',
+        encoding="utf-8",
+    )
+    service = SessionService.synthetic_default(tmp_path)
+
+    service.handle(_command(CommandKind.PAUSE))
+
+    assert service.store.recovered_stale_writer
+    assert service.store.writer_metadata_path.is_file()
+    service.close()
+    assert not service.store.writer_metadata_path.exists()
+
+
+def test_writer_lease_recovers_after_process_is_killed(tmp_path: Path) -> None:
+    ready_path = tmp_path / "writer-ready"
+    child_script = """
+import sys
+import time
+from pathlib import Path
+from heartwood.core_adapter import SessionService
+from heartwood.session import CommandKind, SessionCommand
+
+root = Path(sys.argv[1])
+service = SessionService.synthetic_default(root)
+service.handle(
+    SessionCommand(
+        command_id="killed-pause",
+        session_id="session-synthetic-001",
+        kind=CommandKind.PAUSE,
+        actor_id="child",
+        created_at="2026-01-01T00:00:00Z",
+    )
+)
+(root / "writer-ready").write_text("ready", encoding="utf-8")
+time.sleep(30)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", child_script, str(tmp_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        for _ in range(100):
+            if ready_path.exists() or process.poll() is not None:
+                break
+            time.sleep(0.05)
+        detail = (
+            process.stderr.read()
+            if process.poll() is not None and process.stderr is not None
+            else "child writer did not become ready"
+        )
+        assert ready_path.is_file(), detail
+        process.kill()
+        process.communicate(timeout=5)
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.communicate(timeout=5)
+
+    restarted = SessionService.synthetic_default(tmp_path)
+    result = restarted.handle(_command(CommandKind.RESUME, command_id="restarted-resume"))
+
+    assert restarted.store.recovered_stale_writer
+    assert result.events[-1].kind == EventKind.SESSION_RESUMED.value
+    assert len(restarted.replay_events()) == 4
+
+
+def test_interrupted_audit_first_commit_recovers_without_duplicate_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_append = session_state._append_private_json_line
+    append_count = 0
+
+    def interrupt_second_append(path: Path, content: str) -> None:
+        nonlocal append_count
+        append_count += 1
+        if append_count == 2:
+            raise OSError("simulated process interruption")
+        original_append(path, content)
+
+    monkeypatch.setattr(session_state, "_append_private_json_line", interrupt_second_append)
+    service = SessionService.synthetic_default(tmp_path)
+    command = _command(CommandKind.PAUSE)
+    with pytest.raises(OSError, match="simulated process interruption"):
+        service.handle(command)
+    service.store.events_path.write_bytes(b'{"partial"')
+    service.close()
+
+    restarted = SessionService.synthetic_default(tmp_path)
+    replayed = restarted.replay_events()
+    with pytest.raises(SessionRecoveryError, match="interrupted after acceptance"):
+        restarted.handle(command)
+
+    assert not restarted.store.pending_commit_path.exists()
+    assert len(restarted.audit_log.read()) == 1
+    assert len(replayed) == 1
+    assert replayed[0].kind == EventKind.COMMAND_RECEIVED.value
+
+
+def test_tampered_pending_commit_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def interrupt_append(_path: Path, _content: str) -> None:
+        raise OSError("simulated process interruption")
+
+    monkeypatch.setattr(session_state, "_append_private_json_line", interrupt_append)
+    service = SessionService.synthetic_default(tmp_path)
+    with pytest.raises(OSError, match="simulated process interruption"):
+        service.handle(_command(CommandKind.PAUSE))
+    pending = json.loads(service.store.pending_commit_path.read_text(encoding="utf-8"))
+    pending["session_event"]["payload"]["command_id"] = "tampered"
+    service.store.pending_commit_path.write_text(json.dumps(pending), encoding="utf-8")
+    service.close()
+    recovered = FileSessionStore(tmp_path, "session-synthetic-001")
+    recovered.acquire_writer()
+
+    with pytest.raises(SessionRecoveryError, match="do not correspond"):
+        recovered.recover_pending_commit()
+
+
+def test_recovery_does_not_mutate_corrupt_committed_prefix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_append = session_state._append_private_json_line
+    append_count = 0
+
+    def interrupt_second_append(path: Path, content: str) -> None:
+        nonlocal append_count
+        append_count += 1
+        if append_count == 2:
+            raise OSError("simulated process interruption")
+        original_append(path, content)
+
+    monkeypatch.setattr(session_state, "_append_private_json_line", interrupt_second_append)
+    service = SessionService.synthetic_default(tmp_path)
+    with pytest.raises(OSError, match="simulated process interruption"):
+        service.handle(_command(CommandKind.PAUSE))
+    service.store.events_path.write_bytes(b'{"partial"')
+    audit_record = json.loads(service.store.audit_path.read_text(encoding="utf-8"))
+    audit_record["event_type"] = EventKind.SESSION_RESUMED.value
+    service.store.audit_path.write_text(json.dumps(audit_record) + "\n", encoding="utf-8")
+    audit_before = service.store.audit_path.read_bytes()
+    events_before = service.store.events_path.read_bytes()
+    service.close()
+    recovered = FileSessionStore(tmp_path, "session-synthetic-001")
+    recovered.acquire_writer()
+
+    with pytest.raises(SessionRecoveryError, match="existing audit prefix is invalid"):
+        recovered.recover_pending_commit()
+
+    assert recovered.audit_path.read_bytes() == audit_before
+    assert recovered.events_path.read_bytes() == events_before
+
+
+def test_command_remains_uncertain_if_completion_receipt_write_is_interrupted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_write = session_state._write_private_json_atomic
+
+    def interrupt_completion(path: Path, payload: dict[str, object]) -> None:
+        if path.parent.name == ".commands" and payload.get("state") == "completed":
+            raise OSError("simulated receipt interruption")
+        original_write(path, payload)
+
+    monkeypatch.setattr(session_state, "_write_private_json_atomic", interrupt_completion)
+    service = SessionService.synthetic_default(tmp_path)
+    command = _command(CommandKind.PAUSE)
+    with pytest.raises(OSError, match="simulated receipt interruption"):
+        service.handle(command)
+    monkeypatch.setattr(session_state, "_write_private_json_atomic", original_write)
+
+    with pytest.raises(SessionRecoveryError, match="will not be executed again automatically"):
+        service.handle(command)
+
+    assert [event.kind for event in service.replay_events()] == [
+        EventKind.COMMAND_RECEIVED.value,
+        EventKind.SESSION_PAUSED.value,
+    ]
+
+
+def test_uncertain_approval_blocks_new_commands_and_cannot_repeat_tool_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool_call = ProposedToolCall(
+        tool_call_id="session-main-action",
+        tool_name="file_editor",
+        risk="medium",
+        summary="write one file",
+    )
+    backend = _RecordingBackend(
+        endpoint="https://model.local.invalid/v1/chat/completions",
+        response=(
+            BackendEvent(kind=BackendEventKind.TOOL_CALL_PROPOSED, tool_call=tool_call),
+            BackendEvent(kind=BackendEventKind.CONFIRMATION_REQUESTED, tool_call=tool_call),
+        ),
+    )
+    service = SessionService.local_default(
+        tmp_path,
+        backend=backend,
+        clock=lambda: "2026-01-01T00:00:00Z",
+    )
+    service.handle(
+        _command(CommandKind.CHAT, prompt="write").model_copy(update={"session_id": "session-main"})
+    )
+    original_write = session_state._write_private_json_atomic
+
+    def interrupt_approval_completion(path: Path, payload: dict[str, object]) -> None:
+        if (
+            path.parent.name == ".commands"
+            and payload.get("command_id") == "command-approve"
+            and payload.get("state") == "completed"
+        ):
+            raise OSError("simulated approval receipt interruption")
+        original_write(path, payload)
+
+    monkeypatch.setattr(
+        session_state,
+        "_write_private_json_atomic",
+        interrupt_approval_completion,
+    )
+    approval = _command(
+        CommandKind.APPROVE,
+        target_type="tool-call",
+        target_id=tool_call.tool_call_id,
+    ).model_copy(update={"session_id": "session-main"})
+    with pytest.raises(OSError, match="simulated approval receipt interruption"):
+        service.handle(approval)
+    monkeypatch.setattr(session_state, "_write_private_json_atomic", original_write)
+
+    with pytest.raises(SessionRecoveryError, match="cannot accept more work"):
+        service.handle(
+            _command(
+                CommandKind.APPROVE,
+                command_id="command-approve-retry",
+                target_type="tool-call",
+                target_id=tool_call.tool_call_id,
+            ).model_copy(update={"session_id": "session-main"})
+        )
+
+    assert backend.resolutions == [(tool_call.tool_call_id, True)]
+
+
+def test_session_control_files_are_private(tmp_path: Path) -> None:
+    service = SessionService.synthetic_default(tmp_path)
+    service.handle(_command(CommandKind.PAUSE))
+    receipt_paths = tuple(service.store.commands_dir.iterdir())
+
+    assert stat.S_IMODE(service.store.writer_lock_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(service.store.writer_metadata_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(service.store.commands_dir.stat().st_mode) == 0o700
+    assert len(receipt_paths) == 1
+    assert stat.S_IMODE(receipt_paths[0].stat().st_mode) == 0o600
+
+
+def test_command_receipts_cannot_follow_symbolic_link(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.session_dir.mkdir(mode=0o700, parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    store.commands_dir.symlink_to(outside, target_is_directory=True)
+    service = SessionService.synthetic_default(tmp_path)
+
+    with pytest.raises(SessionStoreBoundaryError, match="receipt path"):
+        service.handle(_command(CommandKind.PAUSE))
+
+    assert tuple(outside.iterdir()) == ()
 
 
 def test_replay_rejects_tampered_session_event_payload(tmp_path: Path) -> None:
@@ -89,6 +558,353 @@ def test_file_store_rejects_symbolic_link_session_alias(tmp_path: Path) -> None:
 
     with pytest.raises(SessionStoreBoundaryError, match="symbolic link"):
         FileSessionStore(sessions, "linked-session")
+
+
+def test_session_store_mutations_require_writer_ownership(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    event, audit_event = _event_pair()
+    store.session_dir.mkdir(mode=0o700, parents=True)
+    store.pending_commit_path.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(SessionOwnershipError):
+        store.append_event(event)
+    with pytest.raises(SessionOwnershipError):
+        store.commit_event(event, audit_event)
+    with pytest.raises(SessionRecoveryError, match="writer-owned"):
+        store.recover_pending_commit()
+    with pytest.raises(SessionOwnershipError):
+        store.accept_command(command_id="command", command_hash="sha256:value", first_sequence=0)
+    with pytest.raises(SessionOwnershipError):
+        store.complete_command(
+            command_id="command",
+            command_hash="sha256:value",
+            first_sequence=0,
+            last_sequence=0,
+        )
+    with pytest.raises(SessionOwnershipError):
+        store.record_completed_legacy_command(
+            command_id="command",
+            command_hash="sha256:value",
+            first_sequence=0,
+            last_sequence=0,
+        )
+    with pytest.raises(SessionOwnershipError):
+        store.write_audit_export("synthetic\n")
+    store.release_writer()
+
+
+def test_session_store_rejects_mismatched_commit_identity_and_sequence(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    event, audit_event = _event_pair()
+
+    with pytest.raises(SessionRecoveryError, match="session does not match"):
+        store.commit_event(
+            event,
+            audit_event.model_copy(update={"session_id": "session-other"}),
+        )
+    with pytest.raises(SessionRecoveryError, match="sequences do not match"):
+        store.commit_event(
+            event,
+            audit_event.model_copy(update={"sequence": 1}),
+        )
+
+
+def test_session_store_rejects_symbolic_link_writer_lock(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.session_dir.mkdir(mode=0o700, parents=True)
+    target = tmp_path / "outside-lock"
+    target.touch()
+    store.writer_lock_path.symlink_to(target)
+
+    with pytest.raises(SessionStoreBoundaryError, match="writer lock"):
+        store.acquire_writer()
+
+
+def test_writer_setup_failure_releases_operating_system_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_write = session_state._write_private_json_atomic
+
+    def fail_metadata(path: Path, payload: dict[str, object]) -> None:
+        if path.name == ".writer.json":
+            raise OSError("metadata write failed")
+        original_write(path, payload)
+
+    monkeypatch.setattr(session_state, "_write_private_json_atomic", fail_metadata)
+    first = FileSessionStore(tmp_path, "session-synthetic-001")
+    with pytest.raises(OSError, match="metadata write failed"):
+        first.acquire_writer()
+    monkeypatch.setattr(session_state, "_write_private_json_atomic", original_write)
+    second = FileSessionStore(tmp_path, "session-synthetic-001")
+
+    second.acquire_writer()
+
+    assert second.owns_writer
+
+
+def test_command_receipt_state_machine_rejects_invalid_transitions(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    store.accept_command(
+        command_id="command-one",
+        command_hash="sha256:one",
+        first_sequence=0,
+    )
+
+    assert store.unresolved_command_ids() == ("command-one",)
+    with pytest.raises(SessionRecoveryError, match="already exists"):
+        store.accept_command(
+            command_id="command-one",
+            command_hash="sha256:one",
+            first_sequence=0,
+        )
+    with pytest.raises(SessionRecoveryError, match="sequence is invalid"):
+        store.complete_command(
+            command_id="command-one",
+            command_hash="sha256:one",
+            first_sequence=1,
+            last_sequence=0,
+        )
+    with pytest.raises(SessionRecoveryError, match="receipt changed"):
+        store.complete_command(
+            command_id="command-one",
+            command_hash="sha256:different",
+            first_sequence=0,
+            last_sequence=0,
+        )
+
+    store.complete_command(
+        command_id="command-one",
+        command_hash="sha256:one",
+        first_sequence=0,
+        last_sequence=0,
+    )
+    store.record_completed_legacy_command(
+        command_id="command-one",
+        command_hash="sha256:one",
+        first_sequence=0,
+        last_sequence=0,
+    )
+    assert store.unresolved_command_ids() == ()
+
+
+def test_pending_commit_recovery_rejects_malformed_and_mismatched_state(
+    tmp_path: Path,
+) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    store.pending_commit_path.write_text(
+        '{"schema_version":"unsupported"}\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(SessionRecoveryError, match="unsupported"):
+        store.recover_pending_commit()
+
+    store.pending_commit_path.write_text("{", encoding="utf-8")
+    with pytest.raises(SessionRecoveryError, match="malformed"):
+        store.recover_pending_commit()
+
+    other_event, other_audit = _event_pair(session_id="session-other")
+    _write_pending_commit(store, other_event, other_audit)
+    with pytest.raises(SessionRecoveryError, match="identity does not match"):
+        store.recover_pending_commit()
+
+    event, audit_event = _event_pair()
+    _write_pending_commit(
+        store,
+        event,
+        audit_event.model_copy(update={"event_hash": "sha256:" + "0" * 64}),
+    )
+    with pytest.raises(SessionRecoveryError, match="audit event hash"):
+        store.recover_pending_commit()
+
+
+def test_pending_commit_recovery_rejects_invalid_chain_and_position(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    first_event, first_audit = _event_pair()
+    store.commit_event(first_event, first_audit)
+
+    wrong_position_event, wrong_position_audit = _event_pair(kind=EventKind.SESSION_RESUMED)
+    _write_pending_commit(store, wrong_position_event, wrong_position_audit)
+    with pytest.raises(SessionRecoveryError, match="does not match the pending commit"):
+        store.recover_pending_commit()
+
+    bad_previous = "sha256:" + "f" * 64
+    next_event, next_audit = _event_pair(sequence=1, previous_event_hash=bad_previous)
+    _write_pending_commit(store, next_event, next_audit)
+    with pytest.raises(SessionRecoveryError, match="previous hash does not match"):
+        store.recover_pending_commit()
+
+
+def test_pending_first_commit_rejects_previous_hash(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    event, audit_event = _event_pair(previous_event_hash="sha256:" + "f" * 64)
+    _write_pending_commit(store, event, audit_event)
+
+    with pytest.raises(SessionRecoveryError, match="first pending commit"):
+        store.recover_pending_commit()
+
+
+def test_pending_second_commit_recovers_with_valid_previous_hash(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    first_event, first_audit = _event_pair()
+    store.commit_event(first_event, first_audit)
+    second_event, second_audit = _event_pair(
+        sequence=1,
+        kind=EventKind.SESSION_RESUMED,
+        previous_event_hash=first_audit.event_hash,
+    )
+    _write_pending_commit(store, second_event, second_audit)
+
+    assert store.recover_pending_commit()
+    assert [event.kind for event in store.read_events()] == [
+        EventKind.SESSION_PAUSED.value,
+        EventKind.SESSION_RESUMED.value,
+    ]
+    assert not store.recover_pending_commit()
+
+
+def test_pending_commit_recovers_partial_audit_tail(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    event, audit_event = _event_pair()
+    _write_pending_commit(store, event, audit_event)
+    store.audit_path.write_bytes(b'{"partial"')
+
+    assert store.recover_pending_commit()
+    assert store.audit_path.read_text(encoding="utf-8").endswith("\n")
+    assert len(store.read_events()) == 1
+
+
+def test_command_record_validation_rejects_malformed_receipts(tmp_path: Path) -> None:
+    store = FileSessionStore(tmp_path, "session-synthetic-001")
+    store.acquire_writer()
+    store.commands_dir.mkdir(mode=0o700)
+    path = store._command_path("command")
+
+    path.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(SessionRecoveryError, match="malformed"):
+        store.command_record("command")
+
+    invalid_receipts = (
+        {
+            "schema_version": "heartwood.session-command-receipt.v1",
+            "session_id": store.session_id,
+            "command_id": "command",
+            "command_hash": "sha256:value",
+            "state": "accepted",
+            "first_sequence": -1,
+            "last_sequence": None,
+        },
+        {
+            "schema_version": "heartwood.session-command-receipt.v1",
+            "session_id": store.session_id,
+            "command_id": "command",
+            "command_hash": "sha256:value",
+            "state": "completed",
+            "first_sequence": 0,
+            "last_sequence": None,
+        },
+        {
+            "schema_version": "heartwood.session-command-receipt.v1",
+            "session_id": store.session_id,
+            "command_id": "command",
+            "command_hash": "sha256:value",
+            "state": "accepted",
+            "first_sequence": 0,
+            "last_sequence": 0,
+        },
+    )
+    for receipt in invalid_receipts:
+        path.write_text(json.dumps(receipt), encoding="utf-8")
+        with pytest.raises(SessionRecoveryError, match="receipt"):
+            store.command_record("command")
+
+    other_session = {
+        **invalid_receipts[0],
+        "session_id": "session-other",
+        "first_sequence": 0,
+    }
+    path.write_text(json.dumps(other_session), encoding="utf-8")
+    with pytest.raises(SessionRecoveryError, match="another session"):
+        store.command_record("command")
+
+
+def test_unresolved_receipt_scan_rejects_invalid_storage(tmp_path: Path) -> None:
+    symlink_store = FileSessionStore(tmp_path / "symlink", "session-synthetic-001")
+    symlink_store.session_dir.mkdir(mode=0o700, parents=True)
+    outside = tmp_path / "outside-receipts"
+    outside.mkdir()
+    symlink_store.commands_dir.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(SessionStoreBoundaryError, match="symbolic link"):
+        symlink_store.unresolved_command_ids()
+
+    file_store = FileSessionStore(tmp_path / "file", "session-synthetic-001")
+    file_store.session_dir.mkdir(mode=0o700, parents=True)
+    file_store.commands_dir.write_text("not a directory", encoding="utf-8")
+    with pytest.raises(SessionStoreBoundaryError, match="must be a directory"):
+        file_store.unresolved_command_ids()
+
+    malformed_store = FileSessionStore(tmp_path / "malformed", "session-synthetic-001")
+    malformed_store.commands_dir.mkdir(mode=0o700, parents=True)
+    (malformed_store.commands_dir / "receipt.json").write_text("[]", encoding="utf-8")
+    with pytest.raises(SessionRecoveryError, match="malformed"):
+        malformed_store.unresolved_command_ids()
+    receipt_path = malformed_store.commands_dir / "receipt.json"
+    receipt_path.write_text('{"command_id":7}', encoding="utf-8")
+    with pytest.raises(SessionRecoveryError, match="invalid"):
+        malformed_store.unresolved_command_ids()
+    receipt_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "heartwood.session-command-receipt.v1",
+                "session_id": "session-other",
+                "command_id": "command",
+                "command_hash": "sha256:value",
+                "state": "accepted",
+                "first_sequence": 0,
+                "last_sequence": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SessionRecoveryError, match="another session"):
+        malformed_store.unresolved_command_ids()
+
+
+def test_legacy_command_events_gain_completed_receipt_on_retry(tmp_path: Path) -> None:
+    first = SessionService.synthetic_default(tmp_path)
+    command = _command(CommandKind.PAUSE)
+    original = first.handle(command)
+    first.close()
+    for receipt in first.store.commands_dir.iterdir():
+        receipt.unlink()
+    first.store.commands_dir.rmdir()
+    restarted = SessionService.synthetic_default(tmp_path)
+
+    replayed = restarted.handle(command)
+
+    assert replayed.events == original.events
+    assert replayed.replayed
+    assert restarted.store.command_record(command.command_id) is not None
+
+
+def test_completed_receipt_must_match_persisted_event_range(tmp_path: Path) -> None:
+    service = SessionService.synthetic_default(tmp_path)
+    command = _command(CommandKind.PAUSE)
+    service.handle(command)
+    receipt_path = service.store._command_path(command.command_id)
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["last_sequence"] = 10
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(SessionRecoveryError, match="events do not match"):
+        service.handle(command)
 
 
 def test_task_records_route_decision_and_waits_for_action_confirmation(tmp_path: Path) -> None:
@@ -216,7 +1032,9 @@ def test_second_task_requires_pending_action_resolution(tmp_path: Path) -> None:
     service = SessionService.synthetic_default(tmp_path)
     service.handle(_command(CommandKind.CHAT, prompt="first task"))
 
-    result = service.handle(_command(CommandKind.CHAT, prompt="second task"))
+    result = service.handle(
+        _command(CommandKind.CHAT, command_id="command-chat-2", prompt="second task")
+    )
 
     assert [event.kind for event in result.events] == [
         EventKind.COMMAND_RECEIVED.value,
@@ -352,6 +1170,7 @@ def test_service_restores_all_pending_actions_and_accepts_any_target(tmp_path: P
             update={"session_id": "session-main"}
         )
     )
+    initial_service.close()
 
     restored_backend = _RecordingBackend(endpoint="https://model.local.invalid/v1/chat/completions")
     restored_service = SessionService.local_default(
@@ -359,7 +1178,6 @@ def test_service_restores_all_pending_actions_and_accepts_any_target(tmp_path: P
         backend=restored_backend,
         clock=lambda: "2026-01-01T00:00:00Z",
     )
-    restored_ids = [action.tool_call_id for action in restored_backend.restored_pending]
 
     result = restored_service.handle(
         _command(
@@ -368,6 +1186,7 @@ def test_service_restores_all_pending_actions_and_accepts_any_target(tmp_path: P
             target_id=first.tool_call_id,
         ).model_copy(update={"session_id": "session-main"})
     )
+    restored_ids = [action.tool_call_id for action in restored_backend.restored_pending]
 
     assert restored_ids == [first.tool_call_id, second.tool_call_id]
     assert restored_backend.restored_pending[0].arguments == {"command": "python first.py"}
@@ -601,9 +1420,60 @@ class _RecordingBackend:
         return None
 
 
-def _command(kind: CommandKind, **payload: JsonValue) -> SessionCommand:
+def _event_pair(
+    *,
+    session_id: str = "session-synthetic-001",
+    sequence: int = 0,
+    kind: EventKind = EventKind.SESSION_PAUSED,
+    previous_event_hash: str | None = None,
+) -> tuple[SessionEvent, AuditEvent]:
+    event = SessionEvent(
+        event_id=f"{session_id}-event-{sequence:06d}",
+        session_id=session_id,
+        sequence=sequence,
+        kind=kind,
+        occurred_at="2026-01-01T00:00:00Z",
+        payload={"command_id": "synthetic"},
+        previous_event_hash=previous_event_hash,
+    )
+    audit_event = AuditEvent(
+        event_id=f"{session_id}-audit-{sequence:06d}",
+        session_id=session_id,
+        sequence=sequence,
+        event_type=kind.value,
+        occurred_at=event.occurred_at,
+        payload={"session_event_hash": compute_session_event_hash(event)},
+        previous_event_hash=previous_event_hash,
+        event_hash=None,
+    )
+    return event, audit_event.model_copy(update={"event_hash": compute_event_hash(audit_event)})
+
+
+def _write_pending_commit(
+    store: FileSessionStore,
+    event: SessionEvent,
+    audit_event: AuditEvent,
+) -> None:
+    store.pending_commit_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "heartwood.session-commit.v1",
+                "session_event": event.model_dump(mode="json"),
+                "audit_event": audit_event.model_dump(mode="json"),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _command(
+    kind: CommandKind,
+    *,
+    command_id: str | None = None,
+    **payload: JsonValue,
+) -> SessionCommand:
     return SessionCommand(
-        command_id=f"command-{kind.value.replace('.', '-')}",
+        command_id=command_id or f"command-{kind.value.replace('.', '-')}",
         session_id="session-synthetic-001",
         kind=kind,
         actor_id="human",

--- a/packages/core-adapter/tests/test_session_service.py
+++ b/packages/core-adapter/tests/test_session_service.py
@@ -350,7 +350,7 @@ with store.snapshot():
     def handle_command() -> None:
         try:
             results.append(service.handle(command))
-        except BaseException as error:  # pragma: no cover - asserted through errors
+        except Exception as error:  # pragma: no cover - asserted through errors
             errors.append(error)
 
     worker = threading.Thread(target=handle_command)

--- a/packages/core-adapter/tests/test_session_service.py
+++ b/packages/core-adapter/tests/test_session_service.py
@@ -10,6 +10,7 @@ import json
 import stat
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -296,6 +297,84 @@ service.close()
     assert writer.returncode == 0, f"{writer_stdout}\n{writer_stderr}"
     assert reader.returncode == 0, reader_stderr
     assert reader_stdout.strip() in {"1", "2"}
+
+
+def test_command_waits_for_snapshot_contention_without_stranding_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    holder_script = """
+import sys
+import time
+from pathlib import Path
+from heartwood.core_adapter import FileSessionStore
+
+root = Path(sys.argv[1])
+store = FileSessionStore(root, "session-synthetic-001")
+while not (root / "acquire-snapshot").exists():
+    time.sleep(0.01)
+with store.snapshot():
+    (root / "snapshot-held").write_text("ready", encoding="utf-8")
+    while not (root / "release-snapshot").exists():
+        time.sleep(0.01)
+"""
+    holder = subprocess.Popen(
+        [sys.executable, "-c", holder_script, str(tmp_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    service = SessionService.synthetic_default(tmp_path)
+    command = _command(CommandKind.PAUSE, command_id="contended-pause")
+    results: list[object] = []
+    errors: list[BaseException] = []
+    original_accept = service.store.accept_command
+
+    def accept_then_contend(
+        *,
+        command_id: str,
+        command_hash: str,
+        first_sequence: int,
+    ) -> None:
+        original_accept(
+            command_id=command_id,
+            command_hash=command_hash,
+            first_sequence=first_sequence,
+        )
+        (tmp_path / "acquire-snapshot").write_text("ready", encoding="utf-8")
+        while not (tmp_path / "snapshot-held").exists():
+            time.sleep(0.01)
+
+    monkeypatch.setattr(service.store, "accept_command", accept_then_contend)
+
+    def handle_command() -> None:
+        try:
+            results.append(service.handle(command))
+        except BaseException as error:  # pragma: no cover - asserted through errors
+            errors.append(error)
+
+    worker = threading.Thread(target=handle_command)
+    try:
+        worker.start()
+        _wait_for_process_marker(holder, tmp_path / "snapshot-held")
+        assert service.store.command_record(command.command_id) is not None
+        assert worker.is_alive()
+
+        (tmp_path / "release-snapshot").write_text("continue", encoding="utf-8")
+        holder_stdout, holder_stderr = holder.communicate(timeout=5)
+        worker.join(timeout=5)
+    finally:
+        (tmp_path / "release-snapshot").touch()
+        if holder.poll() is None:
+            holder.kill()
+            holder.communicate(timeout=5)
+        worker.join(timeout=5)
+
+    assert holder.returncode == 0, f"{holder_stdout}\n{holder_stderr}"
+    assert not worker.is_alive()
+    assert errors == []
+    assert len(results) == 1
+    assert service.store.unresolved_command_ids() == ()
 
 
 def test_distinct_sessions_can_mutate_independently(tmp_path: Path) -> None:

--- a/packages/core-adapter/tests/test_session_service.py
+++ b/packages/core-adapter/tests/test_session_service.py
@@ -41,6 +41,13 @@ from heartwood.session import (
 )
 
 
+def test_empty_replay_does_not_create_session_state(tmp_path: Path) -> None:
+    service = SessionService.synthetic_default(tmp_path)
+
+    assert service.replay_events() == ()
+    assert not service.store.session_dir.exists()
+
+
 def test_pause_persists_replayable_events(tmp_path: Path) -> None:
     service = SessionService.synthetic_default(tmp_path)
 
@@ -211,6 +218,84 @@ service.close()
 
     assert blocked.returncode == 23, blocked.stderr
     assert handed_off.returncode == 0, handed_off.stderr
+
+
+def test_replay_waits_for_a_complete_paired_commit(tmp_path: Path) -> None:
+    writer_script = """
+import sys
+import time
+from pathlib import Path
+import heartwood.core_adapter._state as state
+from heartwood.core_adapter import SessionService
+from heartwood.session import CommandKind, SessionCommand
+
+root = Path(sys.argv[1])
+ready = root / "audit-appended"
+release = root / "release-commit"
+original_append = state._append_private_json_line
+
+def pause_after_audit(path, content):
+    original_append(path, content)
+    if path.name == "audit.jsonl" and not ready.exists():
+        ready.write_text("ready", encoding="utf-8")
+        while not release.exists():
+            time.sleep(0.01)
+
+state._append_private_json_line = pause_after_audit
+service = SessionService.synthetic_default(root)
+service.handle(
+    SessionCommand(
+        command_id="paused-pair",
+        session_id="session-synthetic-001",
+        kind=CommandKind.PAUSE,
+        actor_id="writer",
+        created_at="2026-01-01T00:00:00Z",
+    )
+)
+service.close()
+"""
+    reader_script = """
+import sys
+from pathlib import Path
+from heartwood.core_adapter import SessionService
+
+root = Path(sys.argv[1])
+(root / "reader-started").write_text("ready", encoding="utf-8")
+service = SessionService.synthetic_default(root)
+print(len(service.replay_events()))
+service.close()
+"""
+    writer = subprocess.Popen(
+        [sys.executable, "-c", writer_script, str(tmp_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    reader: subprocess.Popen[str] | None = None
+    try:
+        _wait_for_process_marker(writer, tmp_path / "audit-appended")
+        reader = subprocess.Popen(
+            [sys.executable, "-c", reader_script, str(tmp_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        _wait_for_process_marker(reader, tmp_path / "reader-started")
+        time.sleep(0.1)
+        assert reader.poll() is None, reader.stderr.read() if reader.stderr is not None else ""
+
+        (tmp_path / "release-commit").write_text("continue", encoding="utf-8")
+        writer_stdout, writer_stderr = writer.communicate(timeout=5)
+        reader_stdout, reader_stderr = reader.communicate(timeout=5)
+    finally:
+        for process in (writer, reader):
+            if process is not None and process.poll() is None:
+                process.kill()
+                process.communicate(timeout=5)
+
+    assert writer.returncode == 0, f"{writer_stdout}\n{writer_stderr}"
+    assert reader.returncode == 0, reader_stderr
+    assert reader_stdout.strip() in {"1", "2"}
 
 
 def test_distinct_sessions_can_mutate_independently(tmp_path: Path) -> None:
@@ -1418,6 +1503,17 @@ class _RecordingBackend:
 
     def close(self) -> None:
         return None
+
+
+def _wait_for_process_marker(process: subprocess.Popen[str], marker: Path) -> None:
+    for _ in range(100):
+        if marker.is_file():
+            return
+        if process.poll() is not None:
+            stdout, stderr = process.communicate(timeout=5)
+            pytest.fail(f"child process exited before {marker.name}\n{stdout}\n{stderr}")
+        time.sleep(0.05)
+    pytest.fail(f"child process did not create {marker.name}")
 
 
 def _event_pair(

--- a/packages/gateway/src/heartwood/gateway/__init__.py
+++ b/packages/gateway/src/heartwood/gateway/__init__.py
@@ -12,6 +12,7 @@ from heartwood.core_adapter import (
     CommandConflictError,
     SessionOwnershipError,
     SessionRecoveryError,
+    SessionStorageCapabilityError,
 )
 from heartwood.gateway._action_settings import (
     ACTION_MODE_OPTIONS,
@@ -208,6 +209,7 @@ __all__ = [
     "SessionNotFoundError",
     "SessionOwnershipError",
     "SessionRecoveryError",
+    "SessionStorageCapabilityError",
     "SessionSummary",
     "SetupPhase",
     "SkillManager",

--- a/packages/gateway/src/heartwood/gateway/__init__.py
+++ b/packages/gateway/src/heartwood/gateway/__init__.py
@@ -8,6 +8,11 @@
 
 from __future__ import annotations
 
+from heartwood.core_adapter import (
+    CommandConflictError,
+    SessionOwnershipError,
+    SessionRecoveryError,
+)
 from heartwood.gateway._action_settings import (
     ACTION_MODE_OPTIONS,
     ActionModeOption,
@@ -143,6 +148,7 @@ __all__ = [
     "ActionModeOption",
     "ActionSettings",
     "ActionSettingsError",
+    "CommandConflictError",
     "CredentialBindingStatus",
     "CredentialStore",
     "CredentialStoreAvailability",
@@ -200,6 +206,8 @@ __all__ = [
     "SessionCatalogError",
     "SessionGateway",
     "SessionNotFoundError",
+    "SessionOwnershipError",
+    "SessionRecoveryError",
     "SessionSummary",
     "SetupPhase",
     "SkillManager",

--- a/packages/gateway/src/heartwood/gateway/_gateway.py
+++ b/packages/gateway/src/heartwood/gateway/_gateway.py
@@ -372,8 +372,10 @@ class SessionGateway:
     @_serialized_state
     def stop(self) -> None:
         """Close active OpenHands conversations."""
-        self._reset_services()
-        self.credential_store.clear_process_values()
+        try:
+            self._reset_services()
+        finally:
+            self.credential_store.clear_process_values()
 
     @_serialized_state
     def handle(self, command: SessionCommand) -> SessionResult:
@@ -385,7 +387,8 @@ class SessionGateway:
             self.session_catalog.ensure(command.session_id)
         service = self._service(command.session_id)
         result = service.handle(command)
-        self._streams.publish(session_id=command.session_id, events=result.events)
+        if not result.replayed:
+            self._streams.publish(session_id=command.session_id, events=result.events)
         return result
 
     def sessions(self) -> dict[str, object]:
@@ -1266,9 +1269,16 @@ class SessionGateway:
 
     @_serialized_state
     def _reset_services(self) -> None:
-        for service in self._services.values():
-            service.close()
+        services = tuple(self._services.values())
         self._services.clear()
+        errors: list[Exception] = []
+        for service in services:
+            try:
+                service.close()
+            except Exception as error:
+                errors.append(error)
+        if errors:
+            raise ExceptionGroup("unable to close all session services", errors)
 
     @_serialized_state
     def _save_model_selection(self, source: str | None, settings: ModelSettings) -> None:

--- a/packages/gateway/src/heartwood/gateway/_rest.py
+++ b/packages/gateway/src/heartwood/gateway/_rest.py
@@ -16,6 +16,11 @@ from urllib.parse import parse_qs, urlsplit
 
 from pydantic import ValidationError
 
+from heartwood.core_adapter import (
+    CommandConflictError,
+    SessionOwnershipError,
+    SessionRecoveryError,
+)
 from heartwood.gateway._action_settings import ActionSettingsError
 from heartwood.gateway._credentials import CredentialStoreError
 from heartwood.gateway._gateway import SessionGateway
@@ -232,7 +237,13 @@ class RestGateway:
                 after = _optional_int(query.get("after", [None])[0])
             except ValueError:
                 return _error(400, "after query parameter must be an integer")
-            events = self.gateway.replay_events(session_id=session_id, after_sequence=after)
+            try:
+                events = self.gateway.replay_events(
+                    session_id=session_id,
+                    after_sequence=after,
+                )
+            except (SessionOwnershipError, SessionRecoveryError) as error:
+                return _error(409, error)
             return RestResponse(
                 status_code=200,
                 body={"events": [event.model_dump(mode="json") for event in events]},
@@ -281,7 +292,10 @@ class RestGateway:
             return _error(422, error.errors()[0]["msg"])
         if command.session_id != session_id:
             return _error(409, "command session does not match route session")
-        result = self.gateway.handle(command)
+        try:
+            result = self.gateway.handle(command)
+        except (CommandConflictError, SessionOwnershipError, SessionRecoveryError) as error:
+            return _error(409, error)
         return RestResponse(
             status_code=200,
             body={"events": [event.model_dump(mode="json") for event in result.events]},

--- a/packages/gateway/src/heartwood/gateway/_session_catalog.py
+++ b/packages/gateway/src/heartwood/gateway/_session_catalog.py
@@ -18,7 +18,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TextIO
 
-from heartwood.core_adapter import FileSessionStore, SessionStoreBoundaryError
+from heartwood.audit import AuditIntegrityError
+from heartwood.core_adapter import (
+    FileSessionStore,
+    SessionOwnershipError,
+    SessionRecoveryError,
+    SessionStoreBoundaryError,
+)
 from heartwood.session import EventKind, SessionEvent
 
 _SCHEMA_VERSION = "heartwood.session-metadata.v1"
@@ -90,11 +96,11 @@ class SessionCatalog:
         store = _session_store(self.workspace, session_id)
         store.session_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         store.session_dir.chmod(0o700)
+        events, recovery_required = _catalog_events(store)
         metadata_path = store.session_dir / "metadata.json"
         if metadata_path.exists():
             metadata = _read_metadata(metadata_path)
         else:
-            events = store.read_events()
             now = _utc_timestamp()
             metadata = _SessionMetadata(
                 title=_validate_title(title or session_id),
@@ -102,10 +108,15 @@ class SessionCatalog:
                 updated_at=events[-1].occurred_at if events else now,
             )
             _write_metadata(metadata_path, metadata)
-        return _summary(store, metadata)
+        return _summary(
+            store,
+            metadata,
+            events=events,
+            recovery_required=recovery_required,
+        )
 
     def get(self, session_id: str) -> SessionSummary:
-        """Return one session, registering a legacy event store if needed."""
+        """Return one session, registering persisted state if needed."""
         store = _session_store(self.workspace, session_id)
         if not store.session_dir.is_dir() or store.session_dir.is_symlink():
             msg = f"unknown session: {session_id}"
@@ -146,21 +157,39 @@ class SessionCatalog:
             updated_at=_utc_timestamp(),
         )
         _write_metadata(store.session_dir / "metadata.json", metadata)
-        return _summary(store, metadata)
+        events, recovery_required = _catalog_events(store)
+        return _summary(
+            store,
+            metadata,
+            events=events,
+            recovery_required=recovery_required,
+        )
 
 
-def _summary(store: FileSessionStore, metadata: _SessionMetadata) -> SessionSummary:
-    events = store.read_events()
+def _summary(
+    store: FileSessionStore,
+    metadata: _SessionMetadata,
+    *,
+    events: tuple[SessionEvent, ...],
+    recovery_required: bool,
+) -> SessionSummary:
     created_at = events[0].occurred_at if events else metadata.created_at
     updated_at = _latest_timestamp(metadata.updated_at, events)
     return SessionSummary(
         session_id=store.session_id,
         title=metadata.title,
-        status=_session_status(events),
+        status="recovery-required" if recovery_required else _session_status(events),
         created_at=created_at,
         updated_at=updated_at,
         event_count=len(events),
     )
+
+
+def _catalog_events(store: FileSessionStore) -> tuple[tuple[SessionEvent, ...], bool]:
+    try:
+        return store.replay_events(), False
+    except (AuditIntegrityError, SessionOwnershipError, SessionRecoveryError):
+        return (), True
 
 
 def _session_store(workspace: Path, session_id: str) -> FileSessionStore:

--- a/packages/gateway/tests/test_gateway_contract.py
+++ b/packages/gateway/tests/test_gateway_contract.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 from collections.abc import Mapping
@@ -294,6 +295,30 @@ def test_rest_command_routes_through_session_service_and_streams_events(tmp_path
         EventKind.COMMAND_RECEIVED.value,
         EventKind.SESSION_PAUSED.value,
     ]
+
+
+def test_rest_reports_unsupported_session_storage_without_server_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def native_lock_unavailable(_descriptor: int) -> bool:
+        raise OSError(errno.ENOSYS, "synthetic unsupported filesystem")
+
+    monkeypatch.setattr("filelock._unix._lock_fd_nonblocking", native_lock_unavailable)
+    rest = RestGateway(_gateway(tmp_path))
+
+    response = rest.handle(
+        RestRequest(
+            method="POST",
+            path="/sessions/session-1/commands",
+            body=_command(CommandKind.PAUSE),
+        )
+    )
+
+    assert response.status_code == 409
+    assert response.body == {
+        "error": "session storage does not support required process locks: session-1"
+    }
 
 
 def test_rest_command_retry_is_not_published_twice(tmp_path: Path) -> None:

--- a/packages/gateway/tests/test_gateway_contract.py
+++ b/packages/gateway/tests/test_gateway_contract.py
@@ -41,9 +41,15 @@ from heartwood.gateway import (
 from heartwood.session import CommandKind, EventKind, JsonValue, SessionCommand, SessionEvent
 
 
-def _command(kind: CommandKind, *, session_id: str = "session-1", **payload: JsonValue) -> str:
+def _command(
+    kind: CommandKind,
+    *,
+    session_id: str = "session-1",
+    command_id: str | None = None,
+    **payload: JsonValue,
+) -> str:
     command = SessionCommand(
-        command_id=f"{session_id}-{kind.value}",
+        command_id=command_id or f"{session_id}-{kind.value}",
         session_id=session_id,
         kind=kind,
         actor_id="synthetic-user",
@@ -123,6 +129,23 @@ class _BlockingSessionService:
 
     def close(self) -> None:
         self.closed.set()
+
+
+@dataclass
+class _ClosingSessionService:
+    closed: Event
+    fail: bool = False
+
+    def handle(self, _command: SessionCommand) -> SessionResult:
+        return SessionResult(events=())
+
+    def replay_events(self) -> tuple[SessionEvent, ...]:
+        return ()
+
+    def close(self) -> None:
+        self.closed.set()
+        if self.fail:
+            raise RuntimeError("synthetic close failure")
 
 
 def test_projects_isolate_configuration_sessions_and_artifacts(tmp_path: Path) -> None:
@@ -209,6 +232,46 @@ def test_download_completion_waits_for_an_active_session_turn(tmp_path: Path) ->
     assert closed.is_set()
 
 
+def test_gateway_releases_every_session_when_one_backend_close_fails(tmp_path: Path) -> None:
+    first_closed = Event()
+    second_closed = Event()
+    services = {
+        "session-one": _ClosingSessionService(first_closed, fail=True),
+        "session-two": _ClosingSessionService(second_closed),
+    }
+    gateway = SessionGateway(
+        project=ProjectContext(tmp_path),
+        env={},
+        backend_id="deterministic",
+        service_factory=lambda _root, session_id: cast(Any, services[session_id]),
+    )
+    gateway.handle(
+        SessionCommand(
+            command_id="pause-one",
+            session_id="session-one",
+            kind=CommandKind.PAUSE,
+            actor_id="synthetic-user",
+            created_at="2026-01-01T00:00:00Z",
+        )
+    )
+    gateway.handle(
+        SessionCommand(
+            command_id="pause-two",
+            session_id="session-two",
+            kind=CommandKind.PAUSE,
+            actor_id="synthetic-user",
+            created_at="2026-01-01T00:00:00Z",
+        )
+    )
+
+    with pytest.raises(ExceptionGroup, match="unable to close all session services"):
+        gateway.stop()
+
+    assert first_closed.is_set()
+    assert second_closed.is_set()
+    assert gateway._services == {}
+
+
 def test_rest_command_routes_through_session_service_and_streams_events(tmp_path: Path) -> None:
     gateway = _gateway(tmp_path)
     stream = gateway.websocket(session_id="session-1")
@@ -231,6 +294,90 @@ def test_rest_command_routes_through_session_service_and_streams_events(tmp_path
         EventKind.COMMAND_RECEIVED.value,
         EventKind.SESSION_PAUSED.value,
     ]
+
+
+def test_rest_command_retry_is_not_published_twice(tmp_path: Path) -> None:
+    gateway = _gateway(tmp_path)
+    stream = gateway.websocket(session_id="session-1")
+    rest = RestGateway(gateway)
+    body = _command(CommandKind.PAUSE)
+
+    first = rest.handle(RestRequest(method="POST", path="/sessions/session-1/commands", body=body))
+    first_stream_events = stream.receive()
+    retried = rest.handle(
+        RestRequest(method="POST", path="/sessions/session-1/commands", body=body)
+    )
+
+    assert retried == first
+    assert len(first_stream_events) == 2
+    assert stream.receive() == ()
+
+
+def test_browser_to_cli_session_handoff_requires_owner_shutdown(tmp_path: Path) -> None:
+    browser_gateway = _gateway(tmp_path)
+    cli_gateway = _gateway(tmp_path)
+    browser = RestGateway(browser_gateway)
+    cli = RestGateway(cli_gateway)
+    browser_response = browser.handle(
+        RestRequest(
+            method="POST",
+            path="/sessions/session-1/commands",
+            body=_command(CommandKind.PAUSE, command_id="browser-pause"),
+        )
+    )
+
+    blocked = cli.handle(
+        RestRequest(
+            method="POST",
+            path="/sessions/session-1/commands",
+            body=_command(CommandKind.RESUME, command_id="cli-resume"),
+        )
+    )
+    browser_gateway.stop()
+    handed_off = cli.handle(
+        RestRequest(
+            method="POST",
+            path="/sessions/session-1/commands",
+            body=_command(CommandKind.RESUME, command_id="cli-resume"),
+        )
+    )
+
+    assert browser_response.status_code == 200
+    assert blocked.status_code == 409
+    assert "active in another Heartwood process" in str(blocked.body["error"])
+    assert handed_off.status_code == 200
+    assert _events(handed_off)[-1]["kind"] == EventKind.SESSION_RESUMED.value
+
+
+def test_two_gateways_can_mutate_distinct_sessions(tmp_path: Path) -> None:
+    first = RestGateway(_gateway(tmp_path))
+    second = RestGateway(_gateway(tmp_path))
+
+    first_result = first.handle(
+        RestRequest(
+            method="POST",
+            path="/sessions/session-one/commands",
+            body=_command(
+                CommandKind.PAUSE,
+                session_id="session-one",
+                command_id="pause-one",
+            ),
+        )
+    )
+    second_result = second.handle(
+        RestRequest(
+            method="POST",
+            path="/sessions/session-two/commands",
+            body=_command(
+                CommandKind.PAUSE,
+                session_id="session-two",
+                command_id="pause-two",
+            ),
+        )
+    )
+
+    assert first_result.status_code == 200
+    assert second_result.status_code == 200
 
 
 def test_rest_event_replay_supports_reconnect_after_sequence(tmp_path: Path) -> None:

--- a/packages/gateway/tests/test_session_catalog.py
+++ b/packages/gateway/tests/test_session_catalog.py
@@ -57,6 +57,7 @@ def test_catalog_creates_lists_and_renames_private_session_metadata(tmp_path: Pa
 
 def test_catalog_discovers_legacy_event_stores_and_derives_waiting_state(tmp_path: Path) -> None:
     store = FileSessionStore(tmp_path, "legacy-session")
+    store.acquire_writer()
     store.append_event(_event(0, EventKind.COMMAND_RECEIVED, command_id="command-0"))
     store.append_event(
         _event(
@@ -78,6 +79,7 @@ def test_catalog_discovers_legacy_event_stores_and_derives_waiting_state(tmp_pat
 
 def test_catalog_derives_pause_error_and_recovery_states(tmp_path: Path) -> None:
     store = FileSessionStore(tmp_path, "legacy-session")
+    store.acquire_writer()
     catalog = SessionCatalog(tmp_path)
     store.append_event(_event(0, EventKind.SESSION_PAUSED))
     assert catalog.get("legacy-session").status == "paused"

--- a/packages/gateway/tests/test_session_catalog.py
+++ b/packages/gateway/tests/test_session_catalog.py
@@ -8,14 +8,21 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import stat
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
 
-from heartwood.core_adapter import FileSessionStore
+import heartwood.core_adapter._state as session_state
+from heartwood.audit import AuditLog
+from heartwood.core_adapter import FileSessionStore, SessionService
 from heartwood.gateway import (
     ProjectContext,
     RestGateway,
@@ -24,8 +31,16 @@ from heartwood.gateway import (
     SessionCatalogError,
     SessionGateway,
     SessionNotFoundError,
+    SessionSummary,
 )
-from heartwood.session import EventKind, JsonValue, SessionEvent
+from heartwood.session import (
+    CommandKind,
+    EventKind,
+    JsonValue,
+    SessionCommand,
+    SessionEvent,
+    compute_session_event_hash,
+)
 
 
 def _event(sequence: int, kind: EventKind, **payload: JsonValue) -> SessionEvent:
@@ -37,6 +52,20 @@ def _event(sequence: int, kind: EventKind, **payload: JsonValue) -> SessionEvent
         occurred_at=f"2026-01-01T00:00:{sequence:02d}Z",
         payload=payload,
     )
+
+
+def _append_event(store: FileSessionStore, event: SessionEvent) -> None:
+    audit_log = AuditLog(store.audit_path)
+    audit_events = audit_log.read()
+    previous_hash = audit_events[-1].event_hash if audit_events else None
+    paired_event = event.model_copy(update={"previous_event_hash": previous_hash})
+    audit_event = audit_log.prepare(
+        session_id=paired_event.session_id,
+        event_type=str(paired_event.kind),
+        occurred_at=paired_event.occurred_at,
+        payload={"session_event_hash": compute_session_event_hash(paired_event)},
+    )
+    store.commit_event(paired_event, audit_event)
 
 
 def test_catalog_creates_lists_and_renames_private_session_metadata(tmp_path: Path) -> None:
@@ -55,16 +84,17 @@ def test_catalog_creates_lists_and_renames_private_session_metadata(tmp_path: Pa
     assert stat.S_IMODE((session_dir / "metadata.json").stat().st_mode) == 0o600
 
 
-def test_catalog_discovers_legacy_event_stores_and_derives_waiting_state(tmp_path: Path) -> None:
+def test_catalog_discovers_paired_event_stores_and_derives_waiting_state(tmp_path: Path) -> None:
     store = FileSessionStore(tmp_path, "legacy-session")
     store.acquire_writer()
-    store.append_event(_event(0, EventKind.COMMAND_RECEIVED, command_id="command-0"))
-    store.append_event(
+    _append_event(store, _event(0, EventKind.COMMAND_RECEIVED, command_id="command-0"))
+    _append_event(
+        store,
         _event(
             1,
             EventKind.CONFIRMATION_REQUESTED,
             request={"tool_call_id": "tool-1"},
-        )
+        ),
     )
 
     summary = SessionCatalog(tmp_path).list()[0]
@@ -81,17 +111,178 @@ def test_catalog_derives_pause_error_and_recovery_states(tmp_path: Path) -> None
     store = FileSessionStore(tmp_path, "legacy-session")
     store.acquire_writer()
     catalog = SessionCatalog(tmp_path)
-    store.append_event(_event(0, EventKind.SESSION_PAUSED))
+    _append_event(store, _event(0, EventKind.SESSION_PAUSED))
     assert catalog.get("legacy-session").status == "paused"
 
-    store.append_event(_event(1, EventKind.SESSION_RESUMED))
+    _append_event(store, _event(1, EventKind.SESSION_RESUMED))
     assert catalog.get("legacy-session").status == "idle"
 
-    store.append_event(_event(2, EventKind.ERROR_RECORDED, reason="synthetic"))
+    _append_event(store, _event(2, EventKind.ERROR_RECORDED, reason="synthetic"))
     assert catalog.get("legacy-session").status == "error"
 
-    store.append_event(_event(3, EventKind.COMMAND_RECEIVED, command_id="retry"))
+    _append_event(store, _event(3, EventKind.COMMAND_RECEIVED, command_id="retry"))
     assert catalog.get("legacy-session").status == "idle"
+
+
+def test_catalog_recovers_an_interrupted_paired_append_after_process_exit(
+    tmp_path: Path,
+) -> None:
+    writer_script = """
+import os
+import sys
+from pathlib import Path
+import heartwood.core_adapter._state as state
+from heartwood.core_adapter import SessionService
+from heartwood.session import CommandKind, SessionCommand
+
+root = Path(sys.argv[1])
+original_append = state._append_private_json_line
+
+def exit_after_audit(path, content):
+    original_append(path, content)
+    if path.name == "audit.jsonl":
+        os._exit(17)
+
+state._append_private_json_line = exit_after_audit
+service = SessionService.synthetic_default(root)
+service.handle(
+    SessionCommand(
+        command_id="catalog-crash",
+        session_id="session-synthetic-001",
+        kind=CommandKind.PAUSE,
+        actor_id="writer",
+        created_at="2026-01-01T00:00:00Z",
+    )
+)
+"""
+    crashed = subprocess.run(
+        [sys.executable, "-c", writer_script, str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    summary = SessionCatalog(tmp_path).list()[0]
+
+    assert crashed.returncode == 17, crashed.stderr
+    assert summary.session_id == "session-synthetic-001"
+    assert summary.status == "idle"
+    assert summary.event_count == 1
+    assert not (tmp_path / summary.session_id / ".pending-commit.json").exists()
+
+
+def test_catalog_listing_waits_for_a_complete_concurrent_append(tmp_path: Path) -> None:
+    writer_script = """
+import sys
+import time
+from pathlib import Path
+import heartwood.core_adapter._state as state
+from heartwood.core_adapter import SessionService
+from heartwood.session import CommandKind, SessionCommand
+
+root = Path(sys.argv[1])
+ready = root / "catalog-audit-appended"
+release = root / "release-catalog-commit"
+original_append = state._append_private_json_line
+
+def pause_after_audit(path, content):
+    original_append(path, content)
+    if path.name == "audit.jsonl":
+        ready.write_text("ready", encoding="utf-8")
+        while not release.exists():
+            time.sleep(0.01)
+
+state._append_private_json_line = pause_after_audit
+service = SessionService.synthetic_default(root)
+service.handle(
+    SessionCommand(
+        command_id="catalog-concurrent",
+        session_id="session-synthetic-001",
+        kind=CommandKind.PAUSE,
+        actor_id="writer",
+        created_at="2026-01-01T00:00:00Z",
+    )
+)
+service.close()
+"""
+    writer = subprocess.Popen(
+        [sys.executable, "-c", writer_script, str(tmp_path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    result: list[tuple[SessionSummary, ...]] = []
+    reader: threading.Thread | None = None
+    try:
+        _wait_for_marker(writer, tmp_path / "catalog-audit-appended")
+        reader = threading.Thread(target=lambda: result.append(SessionCatalog(tmp_path).list()))
+        reader.start()
+        time.sleep(0.1)
+        assert reader.is_alive()
+
+        (tmp_path / "release-catalog-commit").write_text("continue", encoding="utf-8")
+        writer_stdout, writer_stderr = writer.communicate(timeout=5)
+        reader.join(timeout=5)
+    finally:
+        if writer.poll() is None:
+            writer.kill()
+            writer.communicate(timeout=5)
+
+    assert writer.returncode == 0, f"{writer_stdout}\n{writer_stderr}"
+    assert reader is not None
+    assert not reader.is_alive()
+    assert len(result) == 1
+    assert len(result[0]) == 1
+    summary = result[0][0]
+    assert summary.status == "paused"
+    assert summary.event_count == 2
+
+
+def test_catalog_marks_an_active_interrupted_append_as_recovery_required(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_append = session_state._append_private_json_line
+
+    def fail_after_audit(path: Path, content: str) -> None:
+        original_append(path, content)
+        if path.name == "audit.jsonl":
+            raise OSError("synthetic interrupted append")
+
+    monkeypatch.setattr(session_state, "_append_private_json_line", fail_after_audit)
+    service = SessionService.synthetic_default(tmp_path)
+    command = SessionCommand(
+        command_id="catalog-active-recovery",
+        session_id="session-synthetic-001",
+        kind=CommandKind.PAUSE,
+        actor_id="writer",
+        created_at="2026-01-01T00:00:00Z",
+    )
+    with pytest.raises(OSError, match="synthetic interrupted append"):
+        service.handle(command)
+
+    summary = SessionCatalog(tmp_path).list()[0]
+    service.close()
+
+    assert summary.status == "recovery-required"
+    assert summary.event_count == 0
+
+
+def test_catalog_keeps_unsupported_session_storage_visible(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def native_lock_unavailable(_descriptor: int) -> bool:
+        raise OSError(errno.ENOSYS, "synthetic unsupported filesystem")
+
+    (tmp_path / "session-unsupported").mkdir()
+    monkeypatch.setattr("filelock._unix._lock_fd_nonblocking", native_lock_unavailable)
+
+    summary = SessionCatalog(tmp_path).list()[0]
+
+    assert summary.session_id == "session-unsupported"
+    assert summary.status == "recovery-required"
+    assert summary.event_count == 0
 
 
 def test_catalog_skips_corrupt_metadata_without_hiding_other_sessions(tmp_path: Path) -> None:
@@ -126,7 +317,7 @@ def test_catalog_closes_temporary_descriptor_when_metadata_open_fails(
     with pytest.raises(OSError, match="synthetic open failure"):
         SessionCatalog(tmp_path).create()
 
-    assert len(closed_descriptors) == 1
+    assert closed_descriptors
     session_dir = next(tmp_path.iterdir())
     assert list(session_dir.glob(".metadata-*")) == []
 
@@ -205,3 +396,15 @@ def test_rest_validates_session_metadata_requests(
     response = rest.handle(RestRequest(method=method, path=path, body=body))
 
     assert response.status_code == status_code
+
+
+def _wait_for_marker(process: subprocess.Popen[str], marker: Path) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if marker.exists():
+            return
+        if process.poll() is not None:
+            _, stderr = process.communicate(timeout=1)
+            pytest.fail(f"writer exited before creating {marker.name}: {stderr}")
+        time.sleep(0.01)
+    pytest.fail(f"writer did not create {marker.name}")

--- a/packages/notebook/src/heartwood/notebook/_view_model.py
+++ b/packages/notebook/src/heartwood/notebook/_view_model.py
@@ -14,7 +14,14 @@ from pathlib import Path
 from typing import Literal, cast
 
 from heartwood.gateway import DEFAULT_SESSION_ID, ModelProfile, ProjectContext, SessionGateway
-from heartwood.session import CommandKind, EventKind, JsonValue, SessionCommand, SessionEvent
+from heartwood.session import (
+    CommandKind,
+    EventKind,
+    JsonValue,
+    SessionCommand,
+    SessionEvent,
+    new_command_id,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,7 +127,7 @@ class NotebookSession:
             raise ValueError("notebook project must match the injected gateway project")
         self.session_id = session_id
         self.gateway = SessionGateway(project=self.project) if gateway is None else gateway
-        self._next_command_sequence = len(self.gateway.replay_events(session_id=session_id))
+        self.gateway.replay_events(session_id=session_id)
 
     def chat(self, prompt: str) -> NotebookViewModel:
         """Run one chat turn and return the notebook view model."""
@@ -322,7 +329,6 @@ class NotebookSession:
     def replay(self) -> NotebookViewModel:
         """Replay persisted events as a notebook view model."""
         events = self.gateway.replay_events(session_id=self.session_id)
-        self._next_command_sequence = max(self._next_command_sequence, len(events))
         return build_view_model(events)
 
     def _handle(
@@ -339,10 +345,8 @@ class NotebookSession:
         kind: CommandKind,
         payload: dict[str, JsonValue] | None,
     ) -> SessionCommand:
-        sequence = self._next_command_sequence
-        self._next_command_sequence += 1
         return SessionCommand(
-            command_id=f"{self.session_id}-{kind.value}-{sequence:06d}",
+            command_id=new_command_id(self.session_id, kind),
             session_id=self.session_id,
             kind=kind,
             actor_id="human",

--- a/packages/notebook/tests/test_notebook.py
+++ b/packages/notebook/tests/test_notebook.py
@@ -427,7 +427,7 @@ def test_notebook_initialization_does_not_advertise_a_terra_web_route(
     assert notebook.browser_url(port=9000) is None
 
 
-def test_notebook_session_tracks_command_sequence_without_duplicate_replay(
+def test_notebook_session_uses_unique_commands_without_duplicate_replay(
     tmp_path: Path,
 ) -> None:
     gateway = _CountingGateway()
@@ -442,10 +442,10 @@ def test_notebook_session_tracks_command_sequence_without_duplicate_replay(
     session.pause()
 
     assert gateway.replay_calls == 3
-    assert [command.command_id for command in gateway.commands] == [
-        "notebook-counting-chat-000000",
-        "notebook-counting-pause-000001",
-    ]
+    command_ids = [command.command_id for command in gateway.commands]
+    assert command_ids[0].startswith("notebook-counting-chat-")
+    assert command_ids[1].startswith("notebook-counting-pause-")
+    assert len(set(command_ids)) == 2
 
 
 def test_notebook_context_releases_the_shared_gateway(tmp_path: Path) -> None:

--- a/packages/session/src/heartwood/session/__init__.py
+++ b/packages/session/src/heartwood/session/__init__.py
@@ -22,6 +22,8 @@ from heartwood.session._contracts import (
     JsonValue,
     SessionCommand,
     SessionEvent,
+    compute_session_event_hash,
+    new_command_id,
     validate_session_id,
 )
 
@@ -32,6 +34,8 @@ __all__ = [
     "SessionCommand",
     "SessionEvent",
     "__version__",
+    "compute_session_event_hash",
+    "new_command_id",
     "validate_session_id",
 ]
 

--- a/packages/session/src/heartwood/session/_contracts.py
+++ b/packages/session/src/heartwood/session/_contracts.py
@@ -8,9 +8,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from enum import StrEnum
 from typing import ClassVar, Literal
+from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue
 
@@ -20,6 +23,8 @@ __all__ = [
     "JsonValue",
     "SessionCommand",
     "SessionEvent",
+    "compute_session_event_hash",
+    "new_command_id",
     "validate_session_id",
 ]
 
@@ -47,6 +52,13 @@ class CommandKind(StrEnum):
     RESUME = "resume"
     REPLAY = "replay"
     AUDIT_EXPORT = "audit.export"
+
+
+def new_command_id(session_id: str, kind: CommandKind | str) -> str:
+    """Return an opaque command identifier suitable for retries and persistence."""
+    validate_session_id(session_id)
+    kind_value = kind.value if isinstance(kind, CommandKind) else kind
+    return f"{session_id}-{kind_value}-{uuid4().hex}"
 
 
 class EventKind(StrEnum):
@@ -115,3 +127,14 @@ class SessionEvent(_SessionRecord):
     occurred_at: str = Field(min_length=1)
     payload: dict[str, JsonValue] = Field(default_factory=dict)
     previous_event_hash: str | None = None
+
+
+def compute_session_event_hash(event: SessionEvent) -> str:
+    """Return the deterministic SHA-256 hash of a complete session event."""
+    canonical = json.dumps(
+        event.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"

--- a/packages/webui/src/App.test.tsx
+++ b/packages/webui/src/App.test.tsx
@@ -1495,6 +1495,24 @@ describe("App", () => {
     expect(screen.getByText("Needs attention")).toBeInTheDocument();
   });
 
+  it("surfaces sessions that require persistence recovery", async () => {
+    const client = new FakeClient();
+    client.currentSessions = [
+      {
+        ...sessionSummary("session-recovery"),
+        status: "recovery-required",
+      },
+    ];
+
+    render(<App client={client} initialSessionId="session-recovery" />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: /Synthetic analysis, Recovery required/u,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("supports secondary activity, settings, rejection, and pause controls", async () => {
     const client = new PendingClient();
     client.currentSettings = {

--- a/packages/webui/src/App.test.tsx
+++ b/packages/webui/src/App.test.tsx
@@ -1670,6 +1670,16 @@ class RejectingClient extends FakeClient {
   }
 }
 
+class LostResponseClient extends FakeClient {
+  override postCommand(command: SessionCommand): Promise<SessionEventResponse> {
+    this.commands.push(command);
+    if (this.commands.length === 1) {
+      return Promise.reject(new Error("connection lost after submission"));
+    }
+    return Promise.resolve({ events: [] });
+  }
+}
+
 describe("App error handling", () => {
   it("renders gateway command errors", async () => {
     render(
@@ -1680,6 +1690,35 @@ describe("App error handling", () => {
     fireEvent.click(screen.getByRole("button", { name: "Export audit" }));
 
     expect(await screen.findByText("synthetic gateway failure")).toBeVisible();
+  });
+
+  it("retries an uncertain command with the original command identifier", async () => {
+    const client = new LostResponseClient();
+    client.currentSettings = {
+      ...settings(),
+      active_profile: "heartwood",
+      profiles: [localProfile()],
+    };
+    render(<App client={client} initialSessionId="session-test" />);
+    await waitFor(() => expect(screen.getByLabelText("Task")).toBeEnabled());
+
+    fireEvent.change(screen.getByLabelText("Task"), {
+      target: { value: "Inspect the synthetic cohort" },
+    });
+    fireEvent.click(screen.getByLabelText("Send task"));
+    expect(
+      await screen.findByText("connection lost after submission"),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry request" }));
+    await waitFor(() => expect(client.commands).toHaveLength(2));
+
+    expect(client.commands[1]).toEqual(client.commands[0]);
+    expect(
+      within(
+        screen.getByRole("log", { name: "Conversation transcript" }),
+      ).getAllByText("Inspect the synthetic cohort"),
+    ).toHaveLength(1);
   });
 });
 

--- a/packages/webui/src/App.tsx
+++ b/packages/webui/src/App.tsx
@@ -478,7 +478,7 @@ export const App = ({ client, initialSessionId }: AppProps) => {
     setRequestStatus("busy");
     setError(null);
     try {
-      const command = createCommand(sessionId, kind, events.length, payload);
+      const command = createCommand(sessionId, kind, payload);
       const submittedPrompt = promptContent(payload);
       if (kind === "chat" && submittedPrompt) {
         setLocalConversation((current) => [

--- a/packages/webui/src/App.tsx
+++ b/packages/webui/src/App.tsx
@@ -45,6 +45,7 @@ import type {
   ModelSettings,
   ModelValidation,
   ProjectReadiness,
+  SessionCommand,
   SessionEvent,
   SessionSummary,
   SkillSettings,
@@ -98,6 +99,7 @@ export const App = ({ client, initialSessionId }: AppProps) => {
   const [requestActivity, setRequestActivity] =
     useState<RequestActivity | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [retryCommand, setRetryCommand] = useState<SessionCommand | null>(null);
   const [panel, setPanel] = useState<UtilityPanel>(null);
   const [mobileSessionsOpen, setMobileSessionsOpen] = useState(false);
   const [modelSettings, setModelSettings] = useState<ModelSettings | null>(
@@ -471,35 +473,46 @@ export const App = ({ client, initialSessionId }: AppProps) => {
   const send = async (
     kind: Parameters<typeof createCommand>[1],
     payload: Record<string, JsonValue> = {},
+    existingCommand?: SessionCommand,
   ) => {
     if (sessionId === null || commandInFlight.current) return false;
     commandInFlight.current = true;
+    const command = existingCommand ?? createCommand(sessionId, kind, payload);
     setRequestActivity(requestActivityForCommand(kind));
     setRequestStatus("busy");
     setError(null);
     try {
-      const command = createCommand(sessionId, kind, payload);
       const submittedPrompt = promptContent(payload);
       if (kind === "chat" && submittedPrompt) {
-        setLocalConversation((current) => [
-          ...current,
-          {
-            id: `local-${command.command_id}`,
-            sequence: (events.at(-1)?.sequence ?? -1) + 0.5,
-            role: "user",
-            label: "You",
-            content: submittedPrompt,
-            detail: null,
-            sessionId,
-          },
-        ]);
+        setLocalConversation((current) =>
+          (
+            current.some(
+              (message) => message.id === `local-${command.command_id}`,
+            )
+          ) ?
+            current
+          : [
+              ...current,
+              {
+                id: `local-${command.command_id}`,
+                sequence: (events.at(-1)?.sequence ?? -1) + 0.5,
+                role: "user",
+                label: "You",
+                content: submittedPrompt,
+                detail: null,
+                sessionId,
+              },
+            ],
+        );
       }
       const response = await resolvedClient.postCommand(command);
       setEvents((current) => mergeEvents(current, response.events));
       await refreshSessions();
+      setRetryCommand(null);
       setRequestStatus("idle");
       return true;
     } catch (caught) {
+      setRetryCommand(command);
       setError(errorMessage(caught));
       setRequestStatus("error");
       return false;
@@ -716,11 +729,29 @@ export const App = ({ client, initialSessionId }: AppProps) => {
           {error ?
             <div className="error-banner" role="alert">
               <span>{error}</span>
+              {retryCommand?.session_id === sessionId ?
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    void send(
+                      retryCommand.kind,
+                      retryCommand.payload,
+                      retryCommand,
+                    )
+                  }
+                >
+                  Retry request
+                </Button>
+              : null}
               <Button
                 aria-label="Dismiss error"
                 size="sm"
                 variant="ghost"
-                onClick={() => setError(null)}
+                onClick={() => {
+                  setError(null);
+                  setRetryCommand(null);
+                }}
               >
                 <X size={16} />
               </Button>

--- a/packages/webui/src/client.test.ts
+++ b/packages/webui/src/client.test.ts
@@ -78,18 +78,18 @@ afterEach(() => {
 
 describe("createCommand", () => {
   it("builds the shared session command envelope", () => {
-    const command = createCommand("session-test", "chat", 7, {
+    const command = createCommand("session-test", "chat", {
       prompt: "synthetic",
     });
 
     expect(command).toMatchObject({
       actor_id: "human",
-      command_id: "session-test-chat-000007",
       kind: "chat",
       payload: { prompt: "synthetic" },
       schema_version: "heartwood.session-command.v1",
       session_id: "session-test",
     });
+    expect(command.command_id).toMatch(/^session-test-chat-[0-9a-f]{32}$/);
   });
 });
 
@@ -192,7 +192,7 @@ describe("GatewayClient", () => {
 
     const client = new GatewayClient("/proxy/8767");
     const response = await client.postCommand(
-      createCommand("session-test", "pause", 0),
+      createCommand("session-test", "pause"),
     );
 
     expect(response.events).toHaveLength(1);

--- a/packages/webui/src/client.ts
+++ b/packages/webui/src/client.ts
@@ -96,11 +96,10 @@ export interface HeartwoodClient {
 export const createCommand = (
   sessionId: string,
   kind: CommandKind,
-  sequence: number,
   payload: Record<string, JsonValue> = {},
 ): SessionCommand => ({
   schema_version: "heartwood.session-command.v1",
-  command_id: `${sessionId}-${kind}-${String(sequence).padStart(6, "0")}`,
+  command_id: `${sessionId}-${kind}-${crypto.randomUUID().replaceAll("-", "")}`,
   session_id: sessionId,
   kind,
   actor_id: "human",

--- a/packages/webui/src/components/SessionRail.tsx
+++ b/packages/webui/src/components/SessionRail.tsx
@@ -152,7 +152,8 @@ const formatRelativeDate = (date: Date): string => {
 const sessionStatus = (
   status: SessionSummary["status"],
 ): "default" | "destructive" | "primary" | "success" | "warning" => {
-  if (status === "error") return "destructive";
+  if (status === "error" || status === "recovery-required")
+    return "destructive";
   if (status === "idle") return "success";
   if (status === "paused") return "primary";
   if (status === "waiting") return "warning";
@@ -161,6 +162,7 @@ const sessionStatus = (
 
 const sessionStatusLabel = (status: SessionSummary["status"]): string => {
   if (status === "error") return "Needs attention";
+  if (status === "recovery-required") return "Recovery required";
   if (status === "paused") return "Paused";
   if (status === "waiting") return "Approval needed";
   return "Ready";

--- a/packages/webui/src/types.ts
+++ b/packages/webui/src/types.ts
@@ -50,7 +50,8 @@ export interface SessionEvent {
   previous_event_hash: string | null;
 }
 
-export type SessionStatus = "empty" | "idle" | "waiting" | "paused" | "error";
+export type SessionStatus =
+  "empty" | "idle" | "waiting" | "paused" | "error" | "recovery-required";
 
 export interface SessionSummary {
   session_id: string;

--- a/uv.lock
+++ b/uv.lock
@@ -1539,6 +1539,7 @@ name = "heartwood-core-adapter"
 version = "0.2.0"
 source = { editable = "packages/core-adapter" }
 dependencies = [
+    { name = "filelock" },
     { name = "heartwood-adapters" },
     { name = "heartwood-audit" },
     { name = "heartwood-model-policy" },
@@ -1548,6 +1549,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "filelock", specifier = "==3.32.0" },
     { name = "heartwood-adapters", editable = "packages/adapters" },
     { name = "heartwood-audit", editable = "packages/audit" },
     { name = "heartwood-model-policy", editable = "packages/model-policy" },


### PR DESCRIPTION
### :recycle: Current situation & Problem

Closes #38.

Concurrent interfaces, retries, and interrupted event writes could fork a session or repeat an agent action.

### :gear: Release Notes

- Enforce one interprocess writer for each session.
- Make completed command retries idempotent across restarts.
- Recover verified interrupted event and audit appends without duplicate records.
- Keep uncertain commands read-only so model calls and tool actions cannot be repeated.

### :books: Documentation

Updated session ownership, interface handoff, recovery, and supported storage guidance.

### :white_check_mark: Testing

- 866 Python tests with 90.11% coverage
- Ruff, formatting, mypy, and dependency-lock validation
- 75 web tests, lint, typecheck, and production build
- Strict documentation and versioned-publication builds
- Process ownership, forced termination, restart, retry, journal interruption, storage capability, and browser-to-CLI handoff coverage

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).