### PR TITLE
Validate Immutable GPU Image Digests

### DIFF
--- a/.github/actions/create-immutable-image-tag/action.yml
+++ b/.github/actions/create-immutable-image-tag/action.yml
@@ -211,9 +211,9 @@ runs:
             ;;
         esac
 
-        validated_candidate_digest="${tag_digest}"
+        platform_manifest_digest=""
         if [ "${VALIDATION_MODE}" = "linux-amd64-index" ]; then
-          validated_candidate_digest="$(
+          platform_manifest_digest="$(
             jq -r '
               .manifests[]
               | select(
@@ -225,13 +225,18 @@ runs:
           )"
         fi
         if [ -n "${CANDIDATE_DIGEST}" ] \
-          && [ "${validated_candidate_digest}" != "${CANDIDATE_DIGEST}" ]; then
+          && [ "${tag_digest}" != "${CANDIDATE_DIGEST}" ] \
+          && [ "${platform_manifest_digest}" != "${CANDIDATE_DIGEST}" ]; then
           if [ "${tag_existed}" = "true" ]; then
             echo "immutable ${DIAGNOSTIC_NAME} already exists with a different digest" >&2
           else
             echo "newly created ${DIAGNOSTIC_NAME} does not match validated candidate digest" >&2
           fi
-          echo "expected digest: ${CANDIDATE_DIGEST}; observed digest: ${validated_candidate_digest}" >&2
+          observed_digests="${tag_digest}"
+          if [ -n "${platform_manifest_digest}" ]; then
+            observed_digests="${observed_digests}, ${platform_manifest_digest}"
+          fi
+          echo "expected digest: ${CANDIDATE_DIGEST}; observed digests: ${observed_digests}" >&2
           exit 1
         fi
 

--- a/.github/workflows/gpu-container-pr-validation.yml
+++ b/.github/workflows/gpu-container-pr-validation.yml
@@ -27,6 +27,96 @@ jobs:
           persist-credentials: false
       - name: Validate GPU runtime contract
         uses: ./.github/actions/validate-gpu-contract
+
+  publication:
+    name: Validate Immutable GPU Tag Publication
+    needs: contract
+    runs-on: ubuntu-24.04
+    services:
+      registry:
+        image: registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+        ports:
+          - 5000:5000
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Wait for local registry
+        run: |
+          curl --fail --silent --show-error \
+            --retry 10 --retry-connrefused --retry-delay 1 \
+            http://localhost:5000/v2/ >/dev/null
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
+          buildkitd-config-inline: |
+            [registry."localhost:5000"]
+              http = true
+              insecure = true
+      - name: Build single-platform OCI index by digest
+        id: candidate
+        env:
+          IMAGE_NAME: localhost:5000/heartwood/immutable-tag-test
+        run: |
+          set -euo pipefail
+
+          metadata="${RUNNER_TEMP}/immutable-tag-candidate.json"
+          docker buildx build \
+            --platform linux/amd64 \
+            --provenance=mode=max \
+            --output "type=image,name=${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file "${metadata}" \
+            packages/compliance/tests/fixtures/immutable-image
+          digest="$(jq -r '."containerimage.digest"' "${metadata}")"
+          if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Buildx returned an invalid candidate digest: ${digest}" >&2
+            exit 1
+          fi
+          reference="${IMAGE_NAME}@${digest}"
+          raw="$(docker buildx imagetools inspect --raw "${reference}")"
+          jq --exit-status '
+            .mediaType == "application/vnd.oci.image.index.v1+json"
+            and (
+              [.manifests[] | select(.platform.os == "linux") | .platform.architecture]
+              == ["amd64"]
+            )
+          ' <<<"${raw}" >/dev/null
+          {
+            echo "digest=${digest}"
+            echo "reference=${reference}"
+            echo "tag=${IMAGE_NAME}:immutable"
+          } >> "${GITHUB_OUTPUT}"
+      - name: Create and verify immutable tag
+        id: publish
+        uses: ./.github/actions/create-immutable-image-tag
+        with:
+          candidate-tag: ${{ steps.candidate.outputs.tag }}
+          candidate-references: ${{ steps.candidate.outputs.reference }}
+          candidate-digest: ${{ steps.candidate.outputs.digest }}
+          diagnostic-name: test GPU commit tag
+          flatten: "false"
+          validation-mode: linux-amd64-index
+      - name: Verify idempotent publication
+        id: repeat
+        uses: ./.github/actions/create-immutable-image-tag
+        with:
+          candidate-tag: ${{ steps.candidate.outputs.tag }}
+          candidate-references: ${{ steps.candidate.outputs.reference }}
+          candidate-digest: ${{ steps.candidate.outputs.digest }}
+          diagnostic-name: test GPU commit tag
+          flatten: "false"
+          validation-mode: linux-amd64-index
+      - name: Verify published digest
+        env:
+          CANDIDATE_DIGEST: ${{ steps.candidate.outputs.digest }}
+          PUBLISHED_DIGEST: ${{ steps.publish.outputs.digest }}
+          REPEATED_DIGEST: ${{ steps.repeat.outputs.digest }}
+        run: |
+          test "${PUBLISHED_DIGEST}" = "${CANDIDATE_DIGEST}"
+          test "${REPEATED_DIGEST}" = "${CANDIDATE_DIGEST}"
+
   build:
     name: Build GPU candidate ${{ matrix.target }}
     needs: contract

--- a/.github/workflows/gpu-container-pr-validation.yml
+++ b/.github/workflows/gpu-container-pr-validation.yml
@@ -62,16 +62,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          metadata="${RUNNER_TEMP}/immutable-tag-candidate.json"
+          metadata="${RUNNER_TEMP}/immutable-tag-manifest.json"
           docker buildx build \
             --platform linux/amd64 \
-            --provenance=mode=max \
+            --provenance=false \
             --output "type=image,name=${IMAGE_NAME},push-by-digest=true,name-canonical=true,push=true" \
             --metadata-file "${metadata}" \
             packages/compliance/tests/fixtures/immutable-image
-          digest="$(jq -r '."containerimage.digest"' "${metadata}")"
+          manifest_digest="$(jq -r '."containerimage.digest"' "${metadata}")"
+          if [[ ! "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Buildx returned an invalid manifest digest: ${manifest_digest}" >&2
+            exit 1
+          fi
+          docker buildx imagetools create \
+            --tag "${IMAGE_NAME}:candidate-index" \
+            "${IMAGE_NAME}@${manifest_digest}"
+          inspect_output="$(docker buildx imagetools inspect "${IMAGE_NAME}:candidate-index")"
+          digest="$(awk '$1 == "Digest:" {print $2; exit}' <<<"${inspect_output}")"
           if [[ ! "${digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "Buildx returned an invalid candidate digest: ${digest}" >&2
+            echo "Buildx returned an invalid index digest: ${digest}" >&2
             exit 1
           fi
           reference="${IMAGE_NAME}@${digest}"

--- a/packages/compliance/tests/fixtures/immutable-image/Dockerfile
+++ b/packages/compliance/tests/fixtures/immutable-image/Dockerfile
@@ -1,0 +1,9 @@
+# This source file is part of the Heartwood open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+
+FROM scratch
+
+LABEL org.opencontainers.image.title="Heartwood immutable image test fixture"

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -811,6 +811,10 @@ def test_gpu_publication_validates_main_and_manual_pr_candidates() -> None:
     runner_cleanup = _read("deploy/reclaim-github-runner-space.sh")
     dependency_review = _read(".github/workflows/dependency-review.yml")
     main_build = workflow.split("  build:\n", maxsplit=1)[1].split("\n  promote:\n", maxsplit=1)[0]
+    pull_request_publication = pull_request_workflow.split("  publication:\n", maxsplit=1)[1].split(
+        "\n  build:\n", maxsplit=1
+    )[0]
+    pull_request_build = pull_request_workflow.split("  build:\n", maxsplit=1)[1]
 
     assert "runtime-gpu-nvidia" in workflow
     assert "terra-runtime-gpu-nvidia" in workflow
@@ -828,7 +832,6 @@ def test_gpu_publication_validates_main_and_manual_pr_candidates() -> None:
     assert "bash -n images/scripts/verify_image_revision.sh" in contract_action
     assert "test -x images/scripts/verify_image_revision.sh" in contract_action
     assert ".output=type=cacheonly" in pull_request_workflow
-    assert "push-by-digest=true" not in pull_request_workflow
     assert "packages: write" not in pull_request_workflow
     assert "workflow_call:" in pull_request_workflow
     assert "workflow_dispatch:" not in pull_request_workflow
@@ -849,7 +852,7 @@ def test_gpu_publication_validates_main_and_manual_pr_candidates() -> None:
     assert "packages: write" in publish_job
     assert "push-by-digest=true" in manual_workflow
     assert "targets: runtime-gpu-nvidia" not in manual_workflow
-    assert "mode=max" not in pull_request_workflow
+    assert "mode=max" not in pull_request_build
     assert "mode=max" not in main_build
     assert "cache-from=type=gha" not in main_build
     assert "cache-to=type=gha" not in main_build
@@ -858,6 +861,13 @@ def test_gpu_publication_validates_main_and_manual_pr_candidates() -> None:
     assert "/usr/share/dotnet" in runner_cleanup
     assert "sbom: false" in pull_request_workflow
     assert "provenance: false" in pull_request_workflow
+    assert "registry:2" in pull_request_publication
+    assert "localhost:5000/heartwood/immutable-tag-test" in pull_request_publication
+    assert "push-by-digest=true" in pull_request_publication
+    assert "ghcr.io" not in pull_request_publication
+    assert pull_request_publication.count("uses: ./.github/actions/create-immutable-image-tag") == 2
+    assert "validation-mode: linux-amd64-index" in pull_request_publication
+    assert "Verify idempotent publication" in pull_request_publication
     assert "Promote GPU Channel Tags" in workflow
     assert "workflow_dispatch:" not in workflow
     assert "qualification_configuration:" in qualification

--- a/packages/compliance/tests/test_immutable_image_action.py
+++ b/packages/compliance/tests/test_immutable_image_action.py
@@ -162,7 +162,7 @@ def test_existing_immutable_tag_rejects_conflicting_digest(tmp_path: Path) -> No
 
     assert result.process.returncode == 1
     assert "already exists with a different digest" in result.process.stderr
-    assert f"expected digest: {_DIGEST_A}; observed digest: {_DIGEST_B}" in (result.process.stderr)
+    assert f"expected digest: {_DIGEST_A}; observed digests: {_DIGEST_B}" in (result.process.stderr)
     assert result.state.get("created") is not True
     assert _publish_calls(result.calls) == ()
 
@@ -180,7 +180,7 @@ def test_new_tag_rejects_published_digest_mismatch(tmp_path: Path) -> None:
     assert "newly created test image does not match validated candidate digest" in (
         result.process.stderr
     )
-    assert f"expected digest: {_DIGEST_A}; observed digest: {_DIGEST_B}" in (result.process.stderr)
+    assert f"expected digest: {_DIGEST_A}; observed digests: {_DIGEST_B}" in (result.process.stderr)
     assert result.state["created"] is True
 
 
@@ -245,6 +245,21 @@ def test_linux_amd64_index_is_created_and_validated(tmp_path: Path) -> None:
     assert "--prefer-index=false" not in _publish_calls(result.calls)[0]
 
 
+def test_linux_amd64_index_accepts_an_index_candidate_digest(tmp_path: Path) -> None:
+    index = _image_index([_platform_manifest(_AMD64_DIGEST, "amd64")])
+    result = _run_action(
+        tmp_path,
+        references=f"registry.test/heartwood@{_DIGEST_A}",
+        candidate_digest=_DIGEST_A,
+        validation_mode="linux-amd64-index",
+        state=_state(published_raw=index, tag_digest=_DIGEST_A),
+    )
+
+    assert result.process.returncode == 0, result.process.stderr
+    assert result.output == {"digest": _DIGEST_A}
+    assert result.state["created"] is True
+
+
 def test_existing_linux_amd64_index_validates_the_wrapped_manifest_digest(
     tmp_path: Path,
 ) -> None:
@@ -280,7 +295,7 @@ def test_linux_amd64_index_rejects_a_different_wrapped_manifest_digest(
 
     assert result.process.returncode == 1
     assert "does not match validated candidate digest" in result.process.stderr
-    assert f"expected digest: {_AMD64_DIGEST}; observed digest: {_DIGEST_B}" in (
+    assert f"expected digest: {_AMD64_DIGEST}; observed digests: {_DIGEST_A}, {_DIGEST_B}" in (
         result.process.stderr
     )
 


### PR DESCRIPTION
### :recycle: Current situation & Problem
The generic GPU publisher treated Buildx's OCI index digest as if it were the wrapped `linux/amd64` manifest digest. This caused [Main Validation](https://github.com/SchmiedmayerLab/heartwood/actions/runs/30222962014/job/89848522411) to fail after the candidate image had been built and published successfully.

### :gear: Release Notes
- Validate both single-platform OCI index candidates and wrapped image-manifest candidates.
- Exercise immutable tag creation and idempotent replay against a pinned, ephemeral OCI registry in every PR.

### :books: Documentation
No user-facing behavior changes.

### :white_check_mark: Testing
- `1,099` Python tests passed with `91.43%` coverage.
- `134` compliance tests passed.
- Ruff, mypy, actionlint, yamllint, REUSE, and whitespace checks passed locally.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).