### PR TITLE
Skip Image Promotion for Superseded Main Runs

### DIFF
--- a/.github/actions/check-current-main/action.yml
+++ b/.github/actions/check-current-main/action.yml
@@ -1,0 +1,37 @@
+# This source file is part of the Heartwood open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+
+name: Check Current Main Revision
+description: Determine whether a workflow still represents the current main revision.
+
+inputs:
+  expected-sha:
+    description: Commit SHA represented by the workflow.
+    required: true
+
+outputs:
+  current:
+    description: Whether the workflow commit is still the current main revision.
+    value: ${{ steps.check.outputs.current }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check current main revision
+      id: check
+      shell: bash
+      env:
+        EXPECTED_SHA: ${{ inputs.expected-sha }}
+      run: |
+        set -euo pipefail
+
+        current_main="$(
+          git ls-remote \
+            "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git" \
+            refs/heads/main \
+            | awk '{print $1}'
+        )"
+        bash "${GITHUB_ACTION_PATH}/check.sh" "${EXPECTED_SHA}" "${current_main}"

--- a/.github/actions/check-current-main/check.sh
+++ b/.github/actions/check-current-main/check.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This source file is part of the Heartwood open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+expected_sha="${1:?Expected workflow revision is required}"
+current_main="${2:?Current main revision is required}"
+github_output="${GITHUB_OUTPUT:?GitHub output path is required}"
+
+if [[ ! "${expected_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Invalid expected main revision: ${expected_sha}" >&2
+  exit 1
+fi
+if [[ ! "${current_main}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Unable to resolve the current main revision" >&2
+  exit 1
+fi
+
+if [ "${current_main}" = "${expected_sha}" ]; then
+  echo "current=true" >> "${github_output}"
+  exit 0
+fi
+
+echo "current=false" >> "${github_output}"
+echo "::notice title=Superseded main workflow::Skipping moving image tag promotion for ${expected_sha}; main is ${current_main}."

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -192,18 +192,19 @@ jobs:
           candidate-references: ${{ steps.candidates.outputs.references }}
           diagnostic-name: generic commit tag
           validation-mode: linux-multi-platform-index
+      - name: Check generic moving-tag ownership
+        id: main-revision
+        uses: ./.github/actions/check-current-main
+        with:
+          expected-sha: ${{ github.sha }}
       - name: Promote generic moving tag
+        if: steps.main-revision.outputs.current == 'true'
         env:
           COMMIT_DIGEST: ${{ steps.commit.outputs.digest }}
           GIT_SHA: ${{ github.sha }}
           IMAGE_CHANNEL: edge
           IMAGE_NAME: ${{ steps.image.outputs.name }}
         run: |
-          current_main="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main | awk '{print $1}')"
-          if [ "${current_main}" != "${GIT_SHA}" ]; then
-            echo "refusing to move the generic channel tag from a stale main workflow" >&2
-            exit 1
-          fi
           docker buildx imagetools create \
             --tag "${IMAGE_NAME}:${IMAGE_CHANNEL}" \
             "${IMAGE_NAME}:sha-${GIT_SHA}"
@@ -388,18 +389,19 @@ jobs:
             --platform terra \
             --image-name "${IMAGE_NAME}" \
             --reference "sha-${GIT_SHA}-terra"
+      - name: Check Terra moving-tag ownership
+        id: main-revision
+        uses: ./.github/actions/check-current-main
+        with:
+          expected-sha: ${{ github.sha }}
       - name: Promote Terra moving tag
+        if: steps.main-revision.outputs.current == 'true'
         env:
           COMMIT_DIGEST: ${{ steps.commit.outputs.digest }}
           GIT_SHA: ${{ github.sha }}
           IMAGE_CHANNEL: edge
           IMAGE_NAME: ${{ steps.image.outputs.name }}
         run: |
-          current_main="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main | awk '{print $1}')"
-          if [ "${current_main}" != "${GIT_SHA}" ]; then
-            echo "refusing to move the Terra channel tag from a stale main workflow" >&2
-            exit 1
-          fi
           docker buildx imagetools create --prefer-index=false \
             --tag "${IMAGE_NAME}:${IMAGE_CHANNEL}-terra" \
             "${IMAGE_NAME}:sha-${GIT_SHA}-terra"

--- a/.github/workflows/gpu-container-image.yml
+++ b/.github/workflows/gpu-container-image.yml
@@ -134,16 +134,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check GPU moving-tag ownership
+        id: main-revision
+        uses: ./.github/actions/check-current-main
+        with:
+          expected-sha: ${{ github.sha }}
       - name: Promote validated generic and Terra tags
+        if: steps.main-revision.outputs.current == 'true'
         env:
           GIT_SHA: ${{ github.sha }}
           IMAGE_NAME: ${{ steps.image.outputs.name }}
         run: |
-          current_main="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main | awk '{print $1}')"
-          if [ "${current_main}" != "${GIT_SHA}" ]; then
-            echo "refusing to move GPU channel tags from a stale main workflow" >&2
-            exit 1
-          fi
           for tuple in \
             "gpu-nvidia edge-gpu-nvidia false" \
             "terra-gpu-nvidia edge-terra-gpu-nvidia true"; do

--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: main-validation-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -970,6 +970,16 @@ def test_current_main_action_skips_superseded_workflows(tmp_path: Path) -> None:
     assert invalid.returncode != 0
     assert "Invalid expected main revision" in invalid.stderr
 
+    invalid_current = subprocess.run(
+        ["bash", str(script), expected_sha, "invalid"],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "GITHUB_OUTPUT": str(tmp_path / "invalid-current-output")},
+        text=True,
+    )
+    assert invalid_current.returncode != 0
+    assert "Unable to resolve the current main revision" in invalid_current.stderr
+
 
 def test_gpu_qualification_workflow_offers_every_candidate_configuration() -> None:
     workflow = _read(".github/workflows/gpu-qualification.yml")

--- a/packages/compliance/tests/test_container_assets.py
+++ b/packages/compliance/tests/test_container_assets.py
@@ -804,6 +804,7 @@ def test_gpu_publication_validates_main_and_manual_pr_candidates() -> None:
     workflow = _read(".github/workflows/gpu-container-image.yml")
     manual_workflow = _read(".github/workflows/gpu-container-pr.yml")
     immutable_tag_action = _read(".github/actions/create-immutable-image-tag/action.yml")
+    current_main_action = _read(".github/actions/check-current-main/action.yml")
     pull_request_workflow = _read(".github/workflows/gpu-container-pr-validation.yml")
     pull_request_validation = _read(".github/workflows/pull-request-validation.yml")
     qualification = _read(".github/workflows/gpu-qualification.yml")
@@ -924,10 +925,50 @@ def test_gpu_publication_validates_main_and_manual_pr_candidates() -> None:
     )
     assert "edge-gpu-nvidia" not in main_build
     assert "edge-terra-gpu-nvidia" not in main_build
-    assert "refusing to move GPU channel tags from a stale main workflow" in workflow
+    assert workflow.count("uses: ./.github/actions/check-current-main") == 1
+    assert "if: steps.main-revision.outputs.current == 'true'" in workflow
+    assert 'bash "${GITHUB_ACTION_PATH}/check.sh"' in current_main_action
     assert "promoted ${channel} digest does not match" in workflow
     assert "allow-ghsas: GHSA-w8v5-vhqr-4h9v, GHSA-rrmf-rvhw-rf47" in dependency_review
     assert "GHSA-8fr4-5q9j-m8gm" not in dependency_review
+
+
+def test_current_main_action_skips_superseded_workflows(tmp_path: Path) -> None:
+    script = _repo_root() / ".github/actions/check-current-main/check.sh"
+    expected_sha = "a" * 40
+
+    current_output = tmp_path / "current-output"
+    current = subprocess.run(
+        ["bash", str(script), expected_sha, expected_sha],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "GITHUB_OUTPUT": str(current_output)},
+        text=True,
+    )
+    assert current.returncode == 0
+    assert current_output.read_text(encoding="utf-8") == "current=true\n"
+
+    stale_output = tmp_path / "stale-output"
+    stale = subprocess.run(
+        ["bash", str(script), expected_sha, "b" * 40],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "GITHUB_OUTPUT": str(stale_output)},
+        text=True,
+    )
+    assert stale.returncode == 0
+    assert stale_output.read_text(encoding="utf-8") == "current=false\n"
+    assert "Superseded main workflow" in stale.stdout
+
+    invalid = subprocess.run(
+        ["bash", str(script), "invalid", expected_sha],
+        check=False,
+        capture_output=True,
+        env={**os.environ, "GITHUB_OUTPUT": str(tmp_path / "invalid-output")},
+        text=True,
+    )
+    assert invalid.returncode != 0
+    assert "Invalid expected main revision" in invalid.stderr
 
 
 def test_gpu_qualification_workflow_offers_every_candidate_configuration() -> None:
@@ -1266,6 +1307,7 @@ def test_launch_scripts_are_valid_and_require_explicit_local_artifact() -> None:
 def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
     publish = _read(".github/workflows/container-image.yml")
     immutable_tag_action = _read(".github/actions/create-immutable-image-tag/action.yml")
+    current_main_action = _read(".github/actions/check-current-main/action.yml")
     smoke = _read(".github/workflows/container-smoke.yml")
     capable_workflow = _read(".github/workflows/capable-model.yml")
     compose = _read("images/generic/compose.yaml")
@@ -1322,8 +1364,10 @@ def test_publish_workflow_uses_digest_merge_and_clean_public_tags() -> None:
         'if raw="$(docker buildx imagetools inspect --raw "${CANDIDATE_TAG}" 2>/dev/null)"; then'
         in immutable_tag_action
     )
-    assert "refusing to move the generic channel tag from a stale main workflow" in publish
-    assert "refusing to move the Terra channel tag from a stale main workflow" in publish
+    assert publish.count("uses: ./.github/actions/check-current-main") == 2
+    assert publish.count("if: steps.main-revision.outputs.current == 'true'") == 2
+    assert "value: ${{ steps.check.outputs.current }}" in current_main_action
+    assert 'bash "${GITHUB_ACTION_PATH}/check.sh"' in current_main_action
     assert publish.index("Build and stage image by digest") < publish.index(
         "Run staged generic OpenHands smoke"
     )

--- a/packages/compliance/tests/test_release_governance.py
+++ b/packages/compliance/tests/test_release_governance.py
@@ -285,7 +285,7 @@ def test_main_validation_owns_release_readiness_dependencies() -> None:
     assert 'to_entries | all(.value.result == "success")' in readiness
     assert "group: main-validation-${{ github.ref }}" in workflow
     assert "  pull_request:" not in workflow
-    assert "cancel-in-progress: false" in workflow
+    assert "cancel-in-progress: true" in workflow
     assert "  pull_request:" in pull_request_workflow
     assert "  push:" not in pull_request_workflow
     assert "name: Release Candidate Ready" in pull_request_workflow


### PR DESCRIPTION
### :recycle: Current situation & Problem

A long-running main validation fails when a newer commit reaches `main` before moving-tag promotion, even though refusing stale promotion is the correct outcome. This occurred in [Main Validation run 30717695898](https://github.com/SchmiedmayerLab/heartwood/actions/runs/30717695898).

### :gear: Release Notes

- Cancel superseded main validation runs to avoid obsolete work.
- Treat superseded generic, Terra, and GPU moving-tag promotions as explicit successful skips.
- Keep immutable-tag, registry, and digest validation failures strict.

### :books: Documentation

No user-facing documentation changes.

### :white_check_mark: Testing

- Full Python suite: 1,337 tests passed with 92.03% coverage.
- Container publication contracts: 31 tests passed.
- Actionlint, yamllint, ShellCheck, Ruff, REUSE, and whitespace checks passed.
- Regression coverage executes current, superseded, and malformed revision decisions.

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
