### PR TITLE
Point the Contribution Guide Link at the Organization Guidelines

### DIFF
--- a/documentation/contribute/index.md
+++ b/documentation/contribute/index.md
@@ -11,7 +11,7 @@ Contributions should preserve the shared project, gateway, OpenHands, interface,
 
 ## Before You Start
 
-Read the repository [contribution guide](https://github.com/SchmiedmayerLab/heartwood/blob/main/CONTRIBUTING.md), [code of conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md), and [AGENTS.md](https://github.com/SchmiedmayerLab/heartwood/blob/main/AGENTS.md).
+Read the repository [contribution guide](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md), [code of conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md), and [AGENTS.md](https://github.com/SchmiedmayerLab/heartwood/blob/main/AGENTS.md).
 Check [GitHub Issues](https://github.com/SchmiedmayerLab/heartwood/issues) and the [Heartwood Project](https://github.com/orgs/SchmiedmayerLab/projects/2) for scoped work and acceptance criteria.
 
 ## Contribution Areas


### PR DESCRIPTION
## :recycle: Current situation

`documentation/contribute/index.md` linked to `heartwood/blob/main/CONTRIBUTING.md`, which does not exist in this repository. The contribution guidelines live in the organization `.github` repository, which is where `README.md` and the code of conduct link beside it already point.

The link check now runs on `main`, so this long-standing 404 surfaced as a failing `Standards / Docs / Markdown Links` job.

## :gear: Release Notes

- Pointed the contribution guide link at `SchmiedmayerLab/.github`, matching the surrounding links.

## :books: Documentation

n/a

## :white_check_mark: Testing

The replacement URL resolves with HTTP 200. `AGENTS.md`, linked on the same line, exists and is unchanged.

## :pencil2: Code of Conduct & Contributing Guidelines

By submitting creations to this repository, I agree to the [Contributor Covenant Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and the [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).