### PR TITLE
Prevent Premature Provider Error Finalization

### DIFF
--- a/packages/gateway/src/heartwood/gateway/_openhands_sdk.py
+++ b/packages/gateway/src/heartwood/gateway/_openhands_sdk.py
@@ -158,6 +158,13 @@ _AGENT_WORKER_SHUTDOWN_TIMEOUT_SECONDS = 30
 _MAX_TOOL_RESULT_CHARS = 16_000
 _MAX_TOOL_RESULT_LINES = 240
 _OPENHANDS_FINISH_TOOL_NAME = "finish"
+_OPENHANDS_ERROR_STATUSES = frozenset(
+    {
+        ConversationExecutionStatus.ERROR,
+        ConversationExecutionStatus.STUCK,
+        ConversationExecutionStatus.DELETING,
+    }
+)
 _SPECIALIST_REGISTRATION_LOCK = Lock()
 _REGISTERED_HEARTWOOD_SPECIALISTS: dict[str, AgentDefinition] = {}
 
@@ -1398,6 +1405,9 @@ class OpenHandsSdkBackend:
         unmatched_actions = ConversationState.get_unmatched_actions(branch)
         unmatched_group = self._unmatched_action_group(conversation)
         lifecycle = _backend_lifecycle(state.execution_status)
+        has_typed_conversation_error = any(
+            isinstance(event, ConversationErrorEvent) for event in branch
+        )
         with self._run_lock:
             run_failed = self._run_failed
             execution_active = self._execution_active
@@ -1405,11 +1415,17 @@ class OpenHandsSdkBackend:
         if (
             execution_active
             and not run_cancelled
-            and state.execution_status
-            in {
-                ConversationExecutionStatus.IDLE,
-                ConversationExecutionStatus.PAUSED,
-            }
+            and (
+                state.execution_status
+                in {
+                    ConversationExecutionStatus.IDLE,
+                    ConversationExecutionStatus.PAUSED,
+                }
+                or (
+                    state.execution_status in _OPENHANDS_ERROR_STATUSES
+                    and not has_typed_conversation_error
+                )
+            )
         ):
             lifecycle = BackendLifecycle.RUNNING
         outcome_error = self._interrupted_outcome_error(conversation)
@@ -1430,16 +1446,9 @@ class OpenHandsSdkBackend:
                     ),
                 )
             )
-        has_typed_conversation_error = any(
-            isinstance(event, ConversationErrorEvent) for event in branch
-        )
         if (
-            state.execution_status
-            in {
-                ConversationExecutionStatus.ERROR,
-                ConversationExecutionStatus.STUCK,
-                ConversationExecutionStatus.DELETING,
-            }
+            state.execution_status in _OPENHANDS_ERROR_STATUSES
+            and not execution_active
             and not run_failed
             and not has_typed_conversation_error
         ):

--- a/packages/gateway/tests/test_openhands_sdk.py
+++ b/packages/gateway/tests/test_openhands_sdk.py
@@ -1290,6 +1290,9 @@ def test_usage_is_transient_during_execution_and_durable_at_the_run_boundary(
     [
         ConversationExecutionStatus.IDLE,
         ConversationExecutionStatus.PAUSED,
+        ConversationExecutionStatus.ERROR,
+        ConversationExecutionStatus.STUCK,
+        ConversationExecutionStatus.DELETING,
     ],
 )
 def test_active_worker_hides_transitional_non_running_sdk_state(
@@ -1317,6 +1320,7 @@ def test_active_worker_hides_transitional_non_running_sdk_state(
 
         assert lifecycle_events
         assert lifecycle_events[-1].lifecycle == BackendLifecycle.RUNNING
+        assert not any(isinstance(event, BackendErrorEvent) for event in events)
     finally:
         with backend._run_lock:
             backend._execution_active = False


### PR DESCRIPTION
### :recycle: Current situation & Problem

The merged 0.3.0 candidate exposed a load-sensitive ordering gap: an intermediate OpenHands error state could publish `HW-AGENT-003` before the typed provider failure was available.

### :gear: Release Notes

- Delay untyped conversation failures until the OpenHands worker reaches a stable boundary.

### :books: Documentation

No user-facing documentation changes.

### :white_check_mark: Testing

- 111 OpenHands adapter and provider-failure tests
- Ruff formatting and lint
- Mypy for the affected gateway package

### Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
